### PR TITLE
Set min-width on mobile version

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -1,6 +1,7 @@
 ::root {
 	--desktop-width: 1050px;
 	--mobile-width: 640px;
+	--min-mobile-width: 320px;
 	--gray-basic: #f5f5f5;
 	--gray-borders: #e3e3e3;
 	--black-basic: #333;

--- a/css/components/footer-logos.css
+++ b/css/components/footer-logos.css
@@ -24,5 +24,6 @@ Styles applied while screen sieze is less than 640px
 @media only screen and (max-width: var(--mobile-width)) {
 	.footer-logos div {
 		flex-wrap: wrap;
+		min-width: var(--min-mobile-width);
 	}
 }

--- a/css/components/header-basic.css
+++ b/css/components/header-basic.css
@@ -53,5 +53,6 @@ Styles applied while screen sieze is less than 640px
 @media only screen and (max-width: var(--mobile-width)) {
 	.header-basic {
 		flex-wrap: wrap;
+		min-width: var(--min-mobile-width);
 	}
 }

--- a/css/components/public-banner.css
+++ b/css/components/public-banner.css
@@ -40,7 +40,8 @@ Styles applied while screen sieze is less than 640px
 */
 @media only screen and (max-width: var(--mobile-width)) {
 		.public-banner .banner-infos {
-				flex-wrap: wrap;
+			flex-wrap: wrap;
+			min-width: var(--min-mobile-width);
 		}
 		.public-banner {
 			min-height: 462px;

--- a/css/components/public-content.css
+++ b/css/components/public-content.css
@@ -27,6 +27,7 @@ Styles applied while screen sieze is less than 640px
 	*/
 	.public-text {
 		flex-wrap: wrap;
+		min-width: var(--min-mobile-width);
 	}
 
 	.public-text .m-box-text-centered {

--- a/css/components/user-guide.css
+++ b/css/components/user-guide.css
@@ -55,6 +55,9 @@ h4.guide-total-costs {
 Styles applied while screen sieze is less than 640px
 */
 @media only screen and (max-width: var(--mobile-width)) {
+	section.business-guide {
+		min-width: var(--min-mobile-width);
+	}
 	section.business-guide fieldset {
 		width: 100%;
 	}

--- a/css/components/user-steps-menu.css
+++ b/css/components/user-steps-menu.css
@@ -45,6 +45,10 @@ nav.steps menuitem button.btn-lg {
 Styles applied while screen sieze is less than 640px
 */
 @media only screen and (max-width: var(--mobile-width)) {
+	div.steps-menu {
+		min-width: var(--min-mobile-width);
+	}
+
 	div.steps-menu nav.steps {
 		display: none;
 	}

--- a/view/prototype/index.html
+++ b/view/prototype/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>eRegistrations</title>
-
+		<meta name="viewport" content="width=device-width" />
 	<script>
 if (!Object.getPrototypeOf || !Object.defineProperty || !window.history ||
 	 (Object.getPrototypeOf({ __proto__: Function.prototype }) !==


### PR DESCRIPTION
In some browsers when widow is shrinked to really small size, page looks as:

![screen shot 2014-07-14 at 08 51 47](https://cloud.githubusercontent.com/assets/122434/3567816/787bb3f8-0b23-11e4-92e5-a09cf5fd7c04.png)
