### PR TITLE
Clear obsolete rules

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -8,17 +8,17 @@
 }
 
 html {
-	font-family: sans-serif;
 	-ms-text-size-adjust: 100%;
 	-webkit-text-size-adjust: 100%;
+	font-family: sans-serif;
 }
 
 body {
-	margin: 0;
+	background-color: #ffffff;
+	color: #333333;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 14px;
-	color: #333333;
-	background-color: #ffffff;
+	margin: 0;
 }
 
 main {
@@ -26,78 +26,77 @@ main {
 }
 
 * {
-	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 *:before,
 *:after {
-	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
 html {
-	font-size: 14px;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+	font-size: 14px;
 }
 
 h1, h2, h3, h4, h5, h6, p {
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	color: var(--dark-background);
-
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 h1 {
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	font-size: 35px;
 	line-height: 44px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 h2 {
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	font-size: 28px;
 	line-height: 44px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 h3 {
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	font-size: 19px;
 	line-height: 22px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 h4 {
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	font-size: 14px;
 	line-height: 22px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 h5 {
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	font-size: 11.6px;
 	line-height: 22px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 h6 {
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	font-size: 10.5px;
 	line-height: 22px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 
 p {
-	font-size: 14px;
+	-webkit-margin-after: 22px;
+	-webkit-margin-before: 0;
 	color: #555;
+	font-size: 14px;
 	line-height: 22px;
 	margin: 0 0 22px 0;
-	-webkit-margin-before: 0;
-	-webkit-margin-after: 22px;
 }
 
 small {
@@ -106,13 +105,13 @@ small {
 }
 
 a {
-	font-size: 14px;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
 }
 
 button {
-	font-size: 14px;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
 }
 
 hr {
@@ -129,8 +128,8 @@ footer {
 }
 
 img {
-	width: 100%;
 	margin-bottom: 22px;
+	width: 100%;
 }
 
 button {
@@ -142,10 +141,10 @@ form {
 }
 
 ul {
-	-webkit-margin-before: 0;
 	-webkit-margin-after: 0;
-	-webkit-margin-start: 0;
+	-webkit-margin-before: 0;
 	-webkit-margin-end: 0;
+	-webkit-margin-start: 0;
 	-webkit-padding-start: 40px;
 	margin: 0 0 22px 0;
 }

--- a/css/components/footer-logos.css
+++ b/css/components/footer-logos.css
@@ -16,7 +16,6 @@
 	justify-content: space-between;
 	margin: 0 auto;
 	max-width: var(--desktop-width);
-
 }
 
 /*

--- a/css/components/header-top.css
+++ b/css/components/header-top.css
@@ -18,16 +18,16 @@ spreaded equaliy in 1050px space. Used i.e. with logo and simple menu
 Flexible basic menu - used on home page and can be reused elsewhere
 */
 .menu-top {
+	-webkit-margin-after: 0px;
+	-webkit-margin-before: 0px;
+	-webkit-margin-end: 0px;
+	-webkit-margin-start: 0px;
+	-webkit-padding-start: 00px;
 	display: flex;
 	height: 100%;
 	list-style: none;
-	-webkit-margin-before: 0px;
-	-webkit-margin-after: 0px;
-	-webkit-margin-start: 0px;
-	-webkit-margin-end: 0px;
-	-webkit-padding-start: 00px;
-	margin-top: 12px;
 	margin-bottom: 10px;
+	margin-top: 12px;
 	padding-left: 0px;
 }
 
@@ -41,7 +41,6 @@ Flexible basic menu link
 }
 
 .menu-top menuitem a.login {
-	-moz-user-select: none;
 	background-color: #428bca;
 	border-color: #357ebd;
 	border-radius: 3px;
@@ -49,8 +48,8 @@ Flexible basic menu link
 	cursor: pointer;
 	font-size: 12px;
 	margin: 0;
-	text-decoration: none;
 	text-align: center;
+	text-decoration: none;
     line-height: 18px;
     padding: 3px 7px 4px;
     vertical-align: middle;
@@ -59,9 +58,9 @@ Flexible basic menu link
 .menu-top menuitem a.login:hover,
 .menu-top menuitem a.login:focus,
 .menu-top menuitem a.login:active {
-	color: #ffffff;
 	background-color: #3071a9;
 	border-color: #285e8e;
+	color: #ffffff;
 }
 /*
 Flexible basic menu button positioning

--- a/css/components/public-banner.css
+++ b/css/components/public-banner.css
@@ -3,12 +3,12 @@ Class describing how home page bunner is displayed as full width cover for i.e
 home page.
 */
 .public-banner {
-		background-image: url('../img/baner.png');
-		background-position: center center;
-		background-size: cover;
-		display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
-		min-height: 374px;
-		width: 100%;
+	background-image: url('../img/baner.png');
+	background-position: center center;
+	background-size: cover;
+	display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
+	min-height: 374px;
+	width: 100%;
 }
 
 /*
@@ -23,63 +23,61 @@ Class describing how boxes for informations insight banner are displayed
 }
 
 .public-banner div.banner-infos a.create-account {
+	background-color: #428bca;
+	background-image: none;
+	border-color: #357ebd;
 	border-radius: 6px;
-    -moz-user-select: none;
-    background-color: #428bca;
-    background-image: none;
-    border-color: #357ebd;
-    border: 1px solid transparent;
-    color: #ffffff;
-    cursor: pointer;
-    display: inline-block;
-    font-size: 18px;
-    font-weight: normal;
-    line-height: 22px;
-    margin-bottom: 0;
-    padding: 10px 16px;
-    text-align: center;
-    text-decoration: none;
-    vertical-align: middle;
-    white-space: nowrap;
+	border: 1px solid transparent;
+	color: #ffffff;
+	cursor: pointer;
+	display: inline-block;
+	font-size: 18px;
+	font-weight: normal;
+	line-height: 22px;
+	margin-bottom: 0;
+	padding: 10px 16px;
+	text-align: center;
+	text-decoration: none;
+	vertical-align: middle;
+	white-space: nowrap;
 }
 
 .public-banner div.banner-infos a.create-account:hover,
 .public-banner div.banner-infos a.create-account:focus,
 .public-banner div.banner-infos a.create-account:active {
-	color: #ffffff;
 	background-color: #3071a9;
 	border-color: #285e8e;
+	color: #ffffff;
 }
 
 .public-steps div a.more-info {
-	-moz-user-select: none;
 	background-color: #428bca;
 	border-color: #357ebd;
 	border-radius: 3px;
 	color: #ffffff;
 	cursor: pointer;
 	font-size: 12px;
+	line-height: 18px;
 	margin: 0;
-	text-decoration: none;
+	padding: 3px 7px 4px;
 	text-align: center;
-    line-height: 18px;
-    padding: 3px 7px 4px;
-    vertical-align: middle;
-    white-space: nowrap;
+	text-decoration: none;
+	vertical-align: middle;
+	white-space: nowrap;
 }
 .public-steps div a.more-info:hover,
 .public-steps div a.more-info:focus,
 .public-steps div a.more-info:active {
-	color: #ffffff;
 	background-color: #3071a9;
 	border-color: #285e8e;
+	color: #ffffff;
 }
 /*
 		Class used for sticking img in banner bottom line, having 50% of banner width
 */
 .baner-box-img {
-		align-self: flex-end;
-		min-width: 50%;
+	align-self: flex-end;
+	min-width: 50%;
 }
 
 .baner-box-img img {

--- a/css/components/public-error.css
+++ b/css/components/public-error.css
@@ -1,31 +1,26 @@
 .public-error {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 0 auto;
-    max-width: var(--desktop-width);
-    padding: 0px 10px;
+	display: flex;
+	flex-wrap: wrap;
+	margin: 0 auto;
+	max-width: var(--desktop-width);
+	padding: 0px 10px;
 }
 
 .public-error div {
-    background-color: #ffffff;
-    border-radius: 5px;
-    border: 1px solid var(--light-inner-border);
-    margin: 22px 0px;
-    text-align: center;
+	background-color: #ffffff;
+	border-radius: 5px;
+	border: 1px solid var(--light-inner-border);
+	margin: 22px 0px;
+	text-align: center;
 }
 
 .public-error div h1, .public-error div h2 {
-    padding-top: 22px;
-    width: 100%;
+	padding-top: 22px;
+	width: 100%;
 }
 
 
 .public-error div h1.error-type {
-    font-size: 84px;
-    line-height: 88px;
-}
-
-.public-error div img {
-    max-height: 396px;
-    max-width: 570px;
+	font-size: 84px;
+	line-height: 88px;
 }

--- a/css/components/public-steps.css
+++ b/css/components/public-steps.css
@@ -20,12 +20,12 @@
 }
 
 .public-steps div:last-child {
-	padding-right: 0px;
 	padding-left: 5px;
+	padding-right: 0px;
 }
 .public-steps img {
-	width: 90%;
 	margin-bottom: 16px;
+	width: 90%;
 }
 
 .public-steps .m-box-text-centered {

--- a/css/components/user-guide.css
+++ b/css/components/user-guide.css
@@ -43,11 +43,10 @@ form.guide-form {
 }
 
 .user-guide button.save-step-one {
-	border-radius: 6px;
-	-moz-user-select: none;
 	background-color: #428bca;
 	background-image: none;
 	border-color: #357ebd;
+	border-radius: 6px;
 	border: 1px solid transparent;
 	color: #ffffff;
 	cursor: pointer;
@@ -65,9 +64,9 @@ form.guide-form {
 .user-guide button.save-step-one:hover,
 .user-guide button.save-step-one:focus,
 .user-guide button.save-step-one:active {
-	color: #ffffff;
 	background-color: #3071a9;
 	border-color: #285e8e;
+	color: #ffffff;
 	text-decoration: none;
 }
 
@@ -79,8 +78,8 @@ h4.guide-total-costs {
 	background-color: var(--light-background);
 	border-bottom: 1px solid black;
 	border-top: 1px solid black;
-	padding: 10px 0;
 	line-height: 22px;
+	padding: 10px 0;
 }
 
 .user-guide button.save-step-one {

--- a/css/components/user-steps-menu.css
+++ b/css/components/user-steps-menu.css
@@ -26,8 +26,8 @@ input[type=checkbox] {
 	display: flex;
 	justify-content: space-between;
 	margin: 0 auto;
-	width: var(--desktop-width);
 	padding: 0px 10px;
+	width: var(--desktop-width);
 }
 
 .steps-menu nav.steps a {
@@ -36,11 +36,10 @@ input[type=checkbox] {
 }
 
 .step-active {
-	border-radius: 6px;
-	-moz-user-select: none;
 	background-color: #428bca;
 	background-image: none;
 	border-color: #357ebd;
+	border-radius: 6px;
 	border: 1px solid transparent;
 	color: #ffffff;
 	cursor: pointer;
@@ -58,14 +57,13 @@ input[type=checkbox] {
 .step-active:hover,
 .step-active:focus,
 .step-active:active {
-	color: #ffffff;
 	background-color: #3071a9;
 	border-color: #285e8e;
+	color: #ffffff;
 	text-decoration: none;
 }
 
 .step-unactive {
-	-moz-user-select: none;
 	background-color: #ffffff;
 	background-image: none;
 	border-color: #357ebd;
@@ -87,10 +85,10 @@ input[type=checkbox] {
 .step-unactive:hover,
 .step-unactive:focus,
 .step-unactive:active {
-	text-decoration: none;
-	color: #333333;
 	background-color: #e6e6e6;
 	border-color: #adadad;
+	color: #333333;
+	text-decoration: none;
 }
 
 .steps-menu nav menuitem {

--- a/view/prototype/guide.js
+++ b/view/prototype/guide.js
@@ -48,7 +48,7 @@ exports.main = function () {
 			h3("Complete the previous questions, pick your records and" +
 					"see the necessary documents and costs"
 			),
-			form({ 'role': 'form', 'class': 'guide-form' },
+			form({ 'class': 'guide-form' },
 				fieldset(h3("Questions"),
 					hr(),
 					ul(li(label(user.getDescriptor('businessActivity').label, " ",


### PR DESCRIPTION
We should strictly rely on pre-processor.

@garfunkel61 provide me with list of all vendor prefixed properties for which we still miss handling in css-aid
