### PR TITLE
Do not use multiple prefixed properties

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -33,14 +33,10 @@ main {
 }
 
 * {
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 *:before,
 *:after {
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
We're using multiple definition of box-sizing, we shouldn't, let's remove it from css (it was already added to css-aid).

Also check if there are any others, we also should clear them
