### PR TITLE
Introduce missing links

### DIFF
--- a/view/prototype/forms.js
+++ b/view/prototype/forms.js
@@ -140,7 +140,7 @@ exports.step = function () {
 			),
 
 		div({ 'class': 'next-step' },
-			a("Continue to next step")
+			a({ href: '/documents/' }, "Continue to next step")
 			),
 		div({ 'class': 'disabler' })
 	);

--- a/view/prototype/index.js
+++ b/view/prototype/index.js
@@ -26,7 +26,7 @@ exports.main = function () {
 			h3('Create your file'),
 			p("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut" +
 				" nequepharetra, pellentesque risus in, condimentum nulla. "),
-			a({ 'class': 'more-info' },
+			a({ 'class': 'more-info', href: '/guide/' },
 				'More info'
 				)
 			),
@@ -35,7 +35,7 @@ exports.main = function () {
 			h3('Pay costs'),
 			p("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut" +
 				" nequepharetra, pellentesque risus in, condimentum nulla. "),
-			a({ 'class': 'more-info' },
+			a({ 'class': 'more-info', href: '/guide/' },
 				'More info'
 				)
 			),
@@ -44,7 +44,7 @@ exports.main = function () {
 			h3('Remove certificates'),
 			p("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ut" +
 				" nequepharetra, pellentesque risus in, condimentum nulla. "),
-			a({ 'class': 'more-info' },
+			a({ 'class': 'more-info', href: '/guide/' },
 				'More info'
 				))
 		);


### PR DESCRIPTION
More info as below should link to `/guide/`

![screen shot 2014-08-05 at 12 07 42](https://cloud.githubusercontent.com/assets/122434/3809807/60cd7be4-1c88-11e4-8c5e-48804a36bbbd.png)

From forms page link to `/documents/`:

![screen shot 2014-08-05 at 12 17 57](https://cloud.githubusercontent.com/assets/122434/3809933/d9aaa658-1c89-11e4-97b7-f5040373fe7c.png)
