### PR TITLE
Footer background must go to bottom edge

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -40,7 +40,7 @@ body {
 
 main {
 	background-color: var(--light-background);
-	padding-bottom: 22px;
+
 }
 
 * {


### PR DESCRIPTION
Currently we see some gray bar below and then white bar, it must not be the case

![screen shot 2014-08-25 at 14 55 06](https://cloud.githubusercontent.com/assets/122434/4029971/26aae080-2c57-11e4-8fca-70164ddea7d3.png)
