### PR TITLE
Forms: Statuses not working properly

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -189,31 +189,24 @@ textarea {
 
 /* dbjs components */
 /* Default styles */
-.dbjs-input-component .status-missing {
-	color: var(--error-text);
+.dbjs-input-component .status-missing,
+.dbjs-input-component .status-ok,
+.dbjs-input-component .status-error {
 	display:none;
 	font-weight: bold;
 	margin-left:5px;
 	visibility:hidden;
 	line-height: 22px;
+}
+
+.dbjs-input-component .status-missing,
+.dbjs-input-component .status-error  {
+	color: var(--error-text);
+
 }
 
 .dbjs-input-component .status-ok {
 	color: var(--success-text);
-	display:none;
-	font-weight: bold;
-	margin-left:5px;
-	visibility:hidden;
-	line-height: 22px;
-}
-
-.dbjs-input-component .status-error {
-	color: var(--error-text);
-	display:none;
-	font-weight: bold;
-	margin-left:5px;
-	visibility:hidden;
-	line-height: 22px;
 }
 
 @-moz-document url-prefix() {


### PR DESCRIPTION
#### When value changed:

What we see:

![screen shot 2014-08-28 at 16 50 23](https://cloud.githubusercontent.com/assets/122434/4077438/1e8eca06-2ec3-11e4-8a80-7f6af38bcbfc.png)

What is expected:  Required mark should stay, and aside green tick should be very light green (using opacity).
#### When value was saved:

What we see:

![screen shot 2014-08-28 at 16 54 18](https://cloud.githubusercontent.com/assets/122434/4077452/42686824-2ec3-11e4-8b3f-b382bb584691.png)

What is expected: Required mark should stay,
#### When invalid value is input:

What we see:

![screen shot 2014-08-28 at 16 55 30](https://cloud.githubusercontent.com/assets/122434/4077466/62c9621c-2ec3-11e4-9458-996462a185d1.png)

What is expected: Instead of green tick, there should be red cross (error mark). Also if field is required, required mark should be there.
