### PR TITLE
Register modal: style issue

### DIFF
--- a/css/components/modal-register.css
+++ b/css/components/modal-register.css
@@ -12,10 +12,6 @@ Component describing styles for registration modal windows - rules specific only
 	width: 320px;
 }
 
-.modal-register input {
-	margin-right: 20px;
-}
-
 .modal-register fieldset p p:last-child {
 	margin-bottom: -1px;
 }

--- a/view/prototype/_register.js
+++ b/view/prototype/_register.js
@@ -22,6 +22,7 @@ module.exports = modal(
 						"Your password must be at least 6 characters and include at least one number."),
 					p(
 						label(
+							{ class: 'input-aside' },
 							input(
 								{ dbjs: user._isManager, type: 'checkbox' }
 							),


### PR DESCRIPTION
Too big gap between checkbox and label

![eregistrations](https://cloud.githubusercontent.com/assets/122434/4076248/82e50ade-2eb8-11e4-9859-70b39b3ec1ab.png)
