### PR TITLE
Guide: Responsive form view doesn't look good

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -354,7 +354,7 @@ Styles applied while screen sieze is less than 640px
 		font-weight: bold;
 	}
 
-	.form-elements ul.radio, .form-elements ul.radio li {
+	.form-elements ul.radio li {
 		display: block;
 	}
 	.form-elements ul.radio li label {


### PR DESCRIPTION
You can hardly distinguish between main labels and e.g. radio labels. Looks as not really styled

![eregistrations](https://cloud.githubusercontent.com/assets/122434/4076318/31e8bda0-2eb9-11e4-999b-f2cb0a641c9b.png)
