### PR TITLE
Document number bullets should align to first line

### DIFF
--- a/css/components/submitted-documents-list.css
+++ b/css/components/submitted-documents-list.css
@@ -16,10 +16,10 @@
 	counter-increment: li;
 	position: absolute;
 	left: -24px;
-	bottom: 12px;
 	width: 19px;
 	height: 19px;
 	margin-right: 8px;
+	margin-top: 2px;
 	border-top:1px solid var(--normal-dark-background);
 	border-radius: 50%;
 	color:	var(--white-text);


### PR DESCRIPTION
Screen from responsive view:

![screen shot 2014-09-05 at 08 31 06](https://cloud.githubusercontent.com/assets/122434/4160929/51aac0f8-34c6-11e4-94b1-a70c862023f6.png)
