### PR TITLE
Hints miss border-radius and box-shadow

### DIFF
--- a/css/hint.css
+++ b/css/hint.css
@@ -6,6 +6,12 @@
 	position: relative;
 	display: inline-block;
 }
+
+.hint:after {
+	border-radius: 4px;
+	box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
+}
+
 .hint:before, .hint:after {
 	position: absolute;
 	transform: translate3d(0, 0, 0);
@@ -208,18 +214,6 @@
 	transform: translateX(-8px); }
 .hint--always.hint--right:after, .hint--always.hint--right:before {
 	transform: translateX(8px); }
-
-/**
-* source: hint-rounded.scss
-*
-* Defines rounded corner tooltips.
-*
-* Classes added:
-* 1) hint--rounded
-*
-*/
-.hint--rounded:after {
-	border-radius: 4px; }
 
 /**
 * source: hint-effects.scss


### PR DESCRIPTION
On Lomas hints look as here:

![screen shot 2014-09-12 at 09 30 30](https://cloud.githubusercontent.com/assets/122434/4246688/c570af38-3a4e-11e4-9c05-11d06eb49278.png)

While on prototype like that:

![screen shot 2014-09-12 at 09 30 42](https://cloud.githubusercontent.com/assets/122434/4246694/d32587c0-3a4e-11e4-8514-6ffb8a16f5a1.png)

It'll be good to have all of them look as in Lomas
