### PR TITLE
Center footer logos in responsive view

### DIFF
--- a/css/components/footer-logos.css
+++ b/css/components/footer-logos.css
@@ -24,6 +24,7 @@
 @media only screen and (max-width: var(--mobile-width)) {
 	.footer-logos div.logos {
 		flex-wrap: wrap;
+		justify-content: center;
 		min-width: var(--min-mobile-width);
 	}
 	.footer-logos div.logos div {

--- a/css/components/public-steps.css
+++ b/css/components/public-steps.css
@@ -25,6 +25,7 @@
 }
 .public-steps img {
 	margin-bottom: 16px;
+	max-width: 95%;
 }
 
 .public-steps .m-box-text-centered {


### PR DESCRIPTION
It'll look better as centered:

![screen shot 2014-09-15 at 15 13 00](https://cloud.githubusercontent.com/assets/122434/4271606/3ae5c798-3cda-11e4-8a91-f26295100777.png)
