### PR TITLE
User submitted: Styles for no entities messages

### DIFF
--- a/css/components/entity-data-section.css
+++ b/css/components/entity-data-section.css
@@ -67,7 +67,7 @@
 	font-size: 12px;
 	padding: 0 0 0 10px;
 }
-.entity-data-section p {
+.entity-data-section .entity-section-no-data {
 	padding: 11px 0 11px 8px;
 	color: var(--hint-text);
 	font-style: italic;

--- a/view/dbjs/section-entities-table-to-dom.js
+++ b/view/dbjs/section-entities-table-to-dom.js
@@ -31,5 +31,5 @@ module.exports = Object.defineProperty(db.FormEntitiesTable.prototype, 'toDOM',
 								return section.toDOM(document, { headerRank: headerRank + 1 });
 							}));
 					}
-					), ns.p(self.constructor.onEmptyMessage)));
+					), ns.p({ class: 'entity-section-no-data' }, self.constructor.onEmptyMessage)));
 	}));


### PR DESCRIPTION
We forgot about the case where there may be no entities to display in given section. Through generator made by @kamsi we output such empty list, but messages needs some formatting:

![screen shot 2014-10-24 at 12 33 02](https://cloud.githubusercontent.com/assets/122434/4768385/685b154a-5b69-11e4-8870-33294415338d.png)

It's plain `p` element, and if you which you can additionally clasify it here: https://github.com/egovernment/eregistrations/blob/46d922e5a9e485679a7f6aa5b22e622c11e0ac7b/view/dbjs/section-entities-table-to-dom.js#L34
