### PR TITLE
Fix markup of info box

### DIFF
--- a/view/prototype/forms.js
+++ b/view/prototype/forms.js
@@ -18,12 +18,10 @@ exports.step = function () {
 		ul(
 			li(
 				h4("Lorem ipsum dolor sit amet, consectetur adipiscing elit: "),
-				" ",
 				p("Lorem ipsum dolor sit amet, consectetur")
 			),
 			li(
 				h4("Lorem ipsum dolor sit amet, consectetur adipiscing elit: "),
-				" ",
 				p("LoLorem ipsum dolor sit amet, consectetur adipiscing elit. Sed feugiat aliquet massa," +
 					" quis vulputate diam. Morbi non dolor ac tellus finibus commodo. Donec convallis" +
 					" tortor felis, et sodales quam vulputate ac.")


### PR DESCRIPTION
List items currently contain _h4_ aside of plain text, it should not be the case (we should not mix inline and block elements on same level)
