### PR TITLE
App navigation modal should have fixed width

### DIFF
--- a/css/components/app-nav-dialog.css
+++ b/css/components/app-nav-dialog.css
@@ -6,6 +6,7 @@
 	border: 1px var(--light-inner-border);
 	opacity: 0.3;
 	transition: opacity 0.5s ease-out;
+	max-width: 550px;
 }
 .app-nav-dialog:hover {
 	opacity: 1;


### PR DESCRIPTION
On wide screen size it extends badly:

![screen shot 2014-11-14 at 15 03 44](https://cloud.githubusercontent.com/assets/122434/5046864/9a46e8de-6c0f-11e4-90c8-8a18afe15b76.png)
