### PR TITLE
Label-reg in submitted-documents-list

### DIFF
--- a/css/components/label-reg.css
+++ b/css/components/label-reg.css
@@ -9,7 +9,7 @@
 	font-size: 12px;
 	text-transform: uppercase;
 	height: 20px;
-	vertical-align: top;
+	line-height: 22px;
 }
 
 .label-reg.ready {


### PR DESCRIPTION
Label for request abbreviation is align to the bottom of background label instead be centered.
