### PR TITLE
Form section: add new options

### DIFF
--- a/view/dbjs/form-entities-table-to-dom.js
+++ b/view/dbjs/form-entities-table-to-dom.js
@@ -16,6 +16,7 @@ module.exports = Object.defineProperty(db.FormEntitiesTable.prototype, 'toDOMFor
 			this.status,
 			1
 		), 'section-primary completed', 'section-primary') },
+			options.prepend,
 			ns.div(
 				ns.div(
 					ns._if(this.constructor.label,
@@ -65,6 +66,7 @@ module.exports = Object.defineProperty(db.FormEntitiesTable.prototype, 'toDOMFor
 					)
 				)
 			),
+			options.append,
 			ns.p(
 				ns.a(
 					{ class: 'new-entity', href: url(this.constructor.baseUrl + '-add') },


### PR DESCRIPTION
We need two new options for form-entities-table-dom:

prepend
append

which would allow for some custom markup injection at the beginning and at the end of the form-entities-table section
