### PR TITLE
CSS : tooltip with registrations "large" names

### DIFF
--- a/css/components/label-reg.css
+++ b/css/components/label-reg.css
@@ -11,6 +11,9 @@
 	height: 20px;
 	line-height: 22px;
 }
+.label-reg:after {
+	text-transform: none;
+}
 
 .label-reg.ready {
 	background: var(--progress-background);

--- a/view/prototype/user-submitted.js
+++ b/view/prototype/user-submitted.js
@@ -53,12 +53,19 @@ exports['sub-main'] = function () {
 					td("123"),
 					td("29/07/2014"),
 					td(
-						span({ class: 'label-reg ready' }, "Brela"),
-						span({ class: 'label-reg rejected' }, "Tinc"),
-						span({ class: 'label-reg approved' }, "Vat"),
-						span({ class: 'label-reg' }, "Gepf"),
-						span({ class: 'label-reg' }, "Nssf"),
-						span({ class: 'label-reg' }, "Lapf")
+						span({ class: 'hint-optional hint-optional-left label-reg ready',
+							'data-hint': 'Lorem ipsum dolor sit amet' },
+							"Brela"),
+						span({ class: 'hint-optional hint-optional-left label-reg rejected',
+							'data-hint': 'Lorem ipsum dolor sit amet' }, "Tinc"),
+						span({ class: 'hint-optional hint-optional-left label-reg approved',
+							'data-hint': 'Lorem ipsum dolor sit amet' }, "Vat"),
+						span({ class: 'hint-optional hint-optional-left label-reg',
+							'data-hint': 'Lorem ipsum dolor sit amet' }, "Gepf"),
+						span({ class: 'hint-optional hint-optional-left label-reg',
+							'data-hint': 'Lorem ipsum dolor sit amet' }, "Nssf"),
+						span({ class: 'hint-optional hint-optional-left label-reg',
+							'data-hint': 'Lorem ipsum dolor sit amet' }, "Lapf")
 					),
 					td(
 						a(


### PR DESCRIPTION
We would like to have the name of the registration in a tooltip when we mouse over the label. 

![els](https://cloud.githubusercontent.com/assets/3383078/5009037/eef09ae6-6a62-11e4-8b43-53b7d3db1131.jpg)
