### PR TITLE
Labels for Institution and document in statistics breaks to two lines instead one

### DIFF
--- a/css/components/statistics-table.css
+++ b/css/components/statistics-table.css
@@ -44,12 +44,3 @@
 .statistics-table tbody .statstics-table-sub-sub-header td {
 	background: var(--light-background);
 }
-
-.statistics-table-dual-aside tr:not(.statstics-table-sub-header) td:first-child,
-.statistics-table-dual-aside tr:not(.statstics-table-sub-sub-header) td:first-child  {
-	padding-right: 1px;
-}
-.statistics-table-dual-aside tr:not(.statstics-table-sub-header) td:nth-child(2),
-.statistics-table-dual-aside tr:not(.statstics-table-sub-sub-header) td:nth-child(2) {
-	padding-left: 1px;
-}


### PR DESCRIPTION
![screen shot 2014-11-24 at 16 38 48](https://cloud.githubusercontent.com/assets/410106/5167409/49cbeeea-73f8-11e4-9de8-6619c53f0379.png)

Labels should be splitted to two columns.
