### PR TITLE
Part B - "print historial" icon size

### DIFF
--- a/css/components/container-with-nav.css
+++ b/css/components/container-with-nav.css
@@ -5,7 +5,7 @@
 }
 
 .container-with-nav .fa {
-	font-size: 14px;
+	font-size: 20px;
 }
 h1.container-with-nav .fa,
 h2.container-with-nav .fa {


### PR DESCRIPTION
![els](https://cloud.githubusercontent.com/assets/3383078/5281789/07de32e4-7b01-11e4-802d-37d383c0bc73.jpg)

I don't really know, but it seems to me that this icon could be bigger as it seems small and lost in the corner of a big white space.. 

I suggest 20px
