### PR TITLE
Markdown : much less space between p and ul

### DIFF
--- a/css/components/free-form.css
+++ b/css/components/free-form.css
@@ -27,6 +27,7 @@
 	list-style-type: lower-latin;
 }
 
-.free-form > p + ul {
+.free-form > p + ul,
+.free-form > p + ol {
 	margin-top: -22px;
 }


### PR DESCRIPTION
![miempresa_gob_sv](https://cloud.githubusercontent.com/assets/3383078/5394581/45158c0e-813f-11e4-9dba-d10d9c833d02.jpg)

Please set the ul "with" the p  = no margin-bottom after the p if ul is next. 

Also please add a margin-bottom for the last li
