### PR TITLE
Let's move input hint closer to input

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -94,6 +94,8 @@ input[type="search"] {
 	width: 100%;
 	color: var(--hint-text);
 	line-height: 22px;
+	position: relative;
+	bottom: 7px;
 }
 
 input[type="submit"],


### PR DESCRIPTION
As reported here: https://github.com/egovernment/eregistrations-salvador/issues/542

I think best is to achieve it with position: relative. 
In result hint text will misalign with VR, but in general VR will remain maintained
