### PR TITLE
Fix official toolbar markup error

### DIFF
--- a/view/prototype/revision.js
+++ b/view/prototype/revision.js
@@ -108,7 +108,7 @@ exports['sub-main'] = function () {
 		{ class: 'section-primary' },
 		insert(reject),
 		h2("Application revision"),
-		p({ class: 'official-submission-toolbar' },
+		div({ class: 'official-submission-toolbar' },
 			postButton({ buttonClass: 'button-main button-main-success', value: "Approve file" }),
 			postButton({ buttonClass: 'button-main', value: "Send for corrections" }),
 			a({ href: '#reject', class: 'button-main button-main-error' }, "Reject file")),


### PR DESCRIPTION
Error is here:

https://github.com/egovernment/eregistrations/blob/master/view/prototype/revision.js#L111-L114

`postButton` produces `<form>` elements, therefore this markup becomes invalid, and it breaks in legacy view, where `<p>` gets automatically closed before `<form>` element opens
