### PR TITLE
Fix VR of offical users table filter bar

### DIFF
--- a/css/components/users-table-filter-bar.css
+++ b/css/components/users-table-filter-bar.css
@@ -9,7 +9,7 @@
 }
 .users-table-filter-bar > form > *:last-child,
 .users-table-filter-bar > div:last-child  {
-	margin-bottom: 22px;
+	margin-bottom: 11px;
 }
 
 .users-table-filter-bar div,
@@ -22,7 +22,8 @@
 }
 
 .users-table-filter-bar form div {
-	margin-right: 20px;
+	line-height: 44px;
+	margin: -11px 20px 11px 0;
 }
 
 .users-table-filter-bar label {


### PR DESCRIPTION
It looks filter bar breaks VR (it was the case before recent update).

![screen shot 2015-01-19 at 17 06 41](https://cloud.githubusercontent.com/assets/122434/5803319/a8f01230-9ffd-11e4-85b8-408ceb175b8f.png)

It can be fixed applying logic we once had in a forms, where we put `line-height: 44px` and resetting margins taking out 11px from each side. Following changes made it look good on my side:

![screen shot 2015-01-19 at 17 08 09](https://cloud.githubusercontent.com/assets/122434/5803339/d74d0be2-9ffd-11e4-95c4-3404e70d567c.png)

![screen shot 2015-01-19 at 17 09 05](https://cloud.githubusercontent.com/assets/122434/5803350/f01aec98-9ffd-11e4-8586-6b7e539691c7.png)
