### PR TITLE
Support prefilled required properties in section generator

### DIFF
--- a/model/form-section-base.js
+++ b/model/form-section-base.js
@@ -26,6 +26,7 @@ module.exports = memoize(function (db) {
 		resolventValue: { type: db.Base },
 		onIncompleteMessage: { type: StringLine }
 	}, {
+		excludedFromStatusIfFilled: { type: StringLine, multiple: true },
 		actionUrl: { type: StringLine, required: true },
 		resolventProperty: { type: StringLine }
 	});

--- a/model/form-section.js
+++ b/model/form-section.js
@@ -43,7 +43,11 @@ module.exports = memoize(function (db) {
 			this.propertyNames.forEach(function (name) {
 				resolved = this.master.resolveSKeyPath(name);
 				if (!resolved.descriptor.required) return;
-				total++;
+				if (this.constructor.excludedFromStatusIfFilled.has(name) &&
+						_observe(resolved.observable) != null) {
+					return;
+				}
+				++total;
 				if (_observe(resolved.observable) != null) valid++;
 			}, this);
 			return total === 0 ? 1 : valid / total;


### PR DESCRIPTION
We need to tweak validation of _prefilled_ required properties in section statuses.
Instead of doing:

``` javascript
++total;
if (this.prefilled) ++valid;
```

We should do:

``` javascript
if (!this.prefilled) ++total;
```

I imagine we should provide an end point, where names for such properties can be provided on section

This will assure that statuses start from 0 point, and it's very usuful for statistics handling. ELS needs that.
