### PR TITLE
ResolventProperty gives error when switched on/off

### DIFF
--- a/client/legacy/form-section-state-helper.js
+++ b/client/legacy/form-section-state-helper.js
@@ -15,7 +15,7 @@ getContext = function (formEntity, sKeyPath) {
 		arrayFromName = sKeyPath.split('/');
 		sKey = arrayFromName[arrayFromName.length - 1];
 		for (i = 0; i < arrayFromName.length - 1; i++) {
-			context = context[arrayFromName[i]];
+			context = context[arrayFromName[i]] || {};
 		}
 	}
 	return { sKey: sKey, object: context };


### PR DESCRIPTION
During switch on/off resolventProperty gets `context` `undefined` in this function:

``` javascript
$.onEnvUpdate(formId, function () {
                            var result, i, context, domElem, formEntity;
                            formEntity = new Entity();
                            $.dbjsFormFill(formEntity, form);
                            for (i = 0; i < constraints.length; i++) {
                                domElem = $(constraints[i].id);
                                if (!domElem) {
                                    continue;
                                }
                                context = getContext(formEntity, constraints[i].sKeyPath);
                                result = constraints[i].constraint.call(context.object);
                                domElem.toggle(result);
                                if (!result) {
                                    delete context.object[context.sKey];
                                } else {
                                    $.dbjsFormFill(formEntity, form);
                                }
                            }
                        });
```

It is situation on Envie page in Salvador..
