### PR TITLE
Sections : lack of master/owner/key in nested property

### DIFF
--- a/client/legacy/form-section-state-helper.js
+++ b/client/legacy/form-section-state-helper.js
@@ -16,7 +16,7 @@ getContext = function (formEntity, sKeyPath) {
 		sKey = arrayFromName[arrayFromName.length - 1];
 		for (i = 0; i < arrayFromName.length - 1; i++) {
 			context = context[arrayFromName[i]] || { master: formEntity.master,
-				key: arrayFromName[i], owner: context };
+				key: arrayFromName[i], owner: context || formEntity.master };
 		}
 	}
 	return { sKey: sKey, object: context };


### PR DESCRIPTION
eregistrations/client/legacy/form-section-state-helper
`context = context[arrayFromName[i]] || {};`
modify to 
`context = context[arrayFromName[i]] || { master: formEntity.master, key: sKey, owner: formEntity };`
