### PR TITLE
Fix hover and pointer of documents thumbs

### DIFF
--- a/css/components/file-thumb.css
+++ b/css/components/file-thumb.css
@@ -52,6 +52,8 @@
 .file-thumb-action:active {
 	background-color: var(--normal-dark-background);
 	box-shadow: none;
+	cursor: pointer;
+	color: var(--white-text);
 }
 .file-thumb-action span {
 	position: relative;


### PR DESCRIPTION
Hover on download link seems wrong, and pointer on remove is not right.

![screen shot 2015-03-12 at 18 47 00](https://cloud.githubusercontent.com/assets/122434/6624235/4ab26088-c8e8-11e4-9eb1-1bb06031b020.png)
