### PR TITLE
Fix margin in thumbs

### DIFF
--- a/css/components/file-thumb.css
+++ b/css/components/file-thumb.css
@@ -7,8 +7,8 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-around;
-	margin-top: 22px;
-	margin-bottom: 0;
+	margin-top: 11px;
+	margin-bottom: 11px;
 }
 
 .file-thumb-image {


### PR DESCRIPTION
I've just noticed that thumb actions are not naturally far from thumb itself.

We should change `margin-top: 22px` into `margin-top: 11px; margin-bottom: 11px;`

![screen shot 2015-03-23 at 14 13 30](https://cloud.githubusercontent.com/assets/122434/6780642/5eed2dc6-d167-11e4-8b8c-2eca1b3e363b.png)
