### PR TITLE
Improve toDOM view of sections

### DIFF
--- a/view/dbjs/section-to-dom.js
+++ b/view/dbjs/section-to-dom.js
@@ -24,7 +24,6 @@ module.exports = Object.defineProperty(db.FormSection.prototype, 'toDOM',
 								self.constructor.resolventProperty).observable));
 					}, function () {
 						return ns.list(self.propertyNames, function (name) {
-
 							return ns._if(ns.not(
 								ns.eqSloppy(resolvePropertyPath(self.master, name).observable, null)
 							),


### PR DESCRIPTION
We should output only fields with values. All those with `value == null` should be ignored.
Currenlty we get many empty fields, which doesn't look well

![screen shot 2015-03-18 at 16 26 31](https://cloud.githubusercontent.com/assets/122434/6712196/93fde198-cd8b-11e4-966a-6acb61bd3cf7.png)
