### PR TITLE
Fix customizations for multiple

### DIFF
--- a/view/dbjs/multiple.js
+++ b/view/dbjs/multiple.js
@@ -1,27 +1,27 @@
 'use strict';
 
 var MultipleInput = require('dbjs-dom/input/_multiple'),
-		ns = require('mano').domjs.ns,
+		el = require('dom-ext/document/#/make-element').bind(document),
 		d = require('d'),
 		_  = require('mano').i18n;
 
 Object.defineProperties(MultipleInput.prototype, {
 	addLabel: d(
 		function () {
-			return ns.a(
+			return el('a',
 				{ class: 'dbjs-multiple-button-add hint-optional hint-optional-left',
 					'data-hint': _("Add new item") },
-				ns.span({ class: 'fa fa-plus-circle' }, _("Add"))
-			);
+				el('span', { class: 'fa fa-plus-circle' }, _("Add"))
+				);
 		}
 	),
 	deleteLabel: d(
 		function () {
-			return ns.a(
+			return el('a',
 				{ class: 'dbjs-multiple-button-remove hint-optional hint-optional-left',
 					'data-hint': _("Remove this item") },
-				ns.span({ class: 'fa fa-minus-circle' }, _("Remove"))
-			);
+				el('span', { class: 'fa fa-minus-circle' }, _("Remove"))
+				);
 		}
 	)
 });


### PR DESCRIPTION
We shouldn't use domjs, as it's not certain that elements would be used, and if they're not used, they're by force to be injected in document body, which is not what we expect.

Let's instead of `ns.a(..`, `ns.span(..` use `el('a', ...`, `el('span', ...` Where: `el = require('dom-ext/document/#/make-element').bind(document)`
