### PR TITLE
Problem with history list layout

### DIFF
--- a/css/components/submitted-user-history.css
+++ b/css/components/submitted-user-history.css
@@ -12,6 +12,6 @@
 }
 .submitted-user-history tr,
 .submitted-user-history td {
-	padding: 11px 0 10px;
+	padding: 11px 11px 10px;
 	text-align: left;
 }


### PR DESCRIPTION
If the text in on of the columns is long, the columns are too close to each other.

![eregistrations-page-001](https://cloud.githubusercontent.com/assets/7392217/7273967/03a9306e-e8f9-11e4-9190-529734daf4ef.jpg)
