### PR TITLE
user-guide-requirements-list  empty p with ul next

### DIFF
--- a/css/components/user-guide.css
+++ b/css/components/user-guide.css
@@ -29,7 +29,7 @@
 	list-style-type: disc;
 }
 
-.user-guide-requirements-list > li > ul > li {
+.user-guide-requirements-list > li > ul > li:first-child {
 	display: inline-flex;
 }
 


### PR DESCRIPTION
Based on https://github.com/egovernment/eregistrations-salvador/issues/767,

Add .user-guide-requirements-list > li > p:empty + ul {...}

And cross browser FF fix, as well as legacy check. 
