### PR TITLE
Form in mobile mode : difficult to see which field goes with the label

### DIFF
--- a/css/components/section-primary.css
+++ b/css/components/section-primary.css
@@ -138,7 +138,7 @@
 	.section-primary .dbjs-input-component > label {
 		text-align: left;
 		width: 100%;
-		margin: 0;
+		margin: 3px 0 -3px;
 	}
 	.section-primary .dbjs-input-component > .input {
 		width: 100%;


### PR DESCRIPTION
As reported https://github.com/egovernment/eregistrations-lomas/issues/868

I think it would be ok, to move label 3px down (but overall VR needs to be maintained)
