### PR TITLE
Error thrown when a section uses undefined property

### DIFF
--- a/view/dbjs/form-section-group-to-dom.js
+++ b/view/dbjs/form-section-group-to-dom.js
@@ -3,16 +3,14 @@
 var _  = require('mano').i18n.bind('Sections')
   , d  = require('d')
   , db = require('mano').db
-  , ns = require('mano').domjs.ns
-  , forEach = require('es5-ext/object/for-each');
+  , ns = require('mano').domjs.ns;
 
 require('./form-section-base');
 
 module.exports = Object.defineProperty(db.FormSectionGroup.prototype, 'toDOMForm',
 	d(function (document/*, options */) {
 		var mainFormResolvent, actionUrl, options = Object(arguments[1]), url
-		  , customizeData, master = options.master || this.master;
-		customizeData = { subSections: {} };
+		  , master = options.master || this.master;
 		mainFormResolvent = this.getFormResolvent(options);
 		url = options.url || ns.url;
 		actionUrl = url(this.constructor.actionUrl);
@@ -21,7 +19,7 @@ module.exports = Object.defineProperty(db.FormSectionGroup.prototype, 'toDOMForm
 					url(this.constructor.actionUrl + '-add') :
 					url(this.constructor.actionUrl, master.__id__);
 		}
-		customizeData.arrayResult = [customizeData.container = ns.section(
+		return [ns.section(
 			{ class: 'section-primary' },
 			ns.form({ id: this.domId, method: 'post',
 					action: actionUrl,
@@ -36,9 +34,8 @@ module.exports = Object.defineProperty(db.FormSectionGroup.prototype, 'toDOMForm
 				options.prepend,
 				mainFormResolvent.formResolvent,
 				ns.div({ id: mainFormResolvent.affectedSectionId }, ns.list(this.sections,
-					function (subSection, subSectionName) {
+					function (subSection) {
 						var formResolvent, legacy, control;
-						customizeData.subSections[subSectionName] = {};
 						formResolvent = subSection.getFormResolvent(options);
 						legacy = subSection.getLegacy(this.domId, options);
 						if (!subSection.forceRequiredInput) {
@@ -47,7 +44,7 @@ module.exports = Object.defineProperty(db.FormSectionGroup.prototype, 'toDOMForm
 						return ns.div({ class: 'section-primary-sub', id: subSection.domId },
 							ns._if(subSection.label, ns.h3(subSection.label)),
 							formResolvent.formResolvent,
-							customizeData.subSections[subSectionName].fieldset = ns.fieldset(
+							ns.fieldset(
 								{ id: formResolvent.affectedSectionId, class: 'form-elements',
 									dbjs: master, names: subSection.formPropertyNames,
 									control: control,
@@ -63,12 +60,4 @@ module.exports = Object.defineProperty(db.FormSectionGroup.prototype, 'toDOMForm
 				)
 				)
 		), mainFormResolvent.legacyScript];
-		if (typeof options.customize === 'function') {
-			forEach(customizeData.subSections, function (subSection) {
-				subSection.fieldset = subSection.fieldset._dbjsFieldset;
-			});
-			options.customize.call(this, customizeData);
-		}
-
-		return customizeData.arrayResult;
 	}));


### PR DESCRIPTION
The section defined in `sections/authorization-correlatives.js` in `eregistrations-salvador` throws a non-intuitive error `Cannot read proprerty 'id' of null` when a property is missing in the model (`propName = "printAssignment/company"`)

```
resolved = resolvePropertyPath(master, propName);
formFieldPath = resolved.id; 
```
