### PR TITLE
Fix markup of pills-nav component

### DIFF
--- a/css/components/pills-nav.css
+++ b/css/components/pills-nav.css
@@ -29,10 +29,10 @@
 	background: var(--normal-light-background);
 }
 
-.pills-nav-pill-active,
-.pills-nav-pill-active:hover,
-.pills-nav-pill-active:focus,
-.pills-nav-pill-active:active {
+.pills-nav-active > a,
+.pills-nav-active > a:hover,
+.pills-nav-active > a:focus,
+.pills-nav-active > a:active {
 	background: var(--normal-background);
 	color: var(--white-text);
 }

--- a/view/prototype/translations-panel.js
+++ b/view/prototype/translations-panel.js
@@ -22,7 +22,7 @@ exports['submitted-menu'] = function () {
 exports['sub-main'] = function () {
 	ul(
 		{ class: 'pills-nav' },
-		li(a({ class: 'pills-nav-pill pills-nav-pill-active' }, "Lorem ipsum dolor amet")),
+		li({ class: 'pills-nav-active' }, a({ class: 'pills-nav-pill' }, "Lorem ipsum dolor amet")),
 		li(a({ class: 'pills-nav-pill' }, "Lorem ipsum")),
 		li(a({ class: 'pills-nav-pill' }, "Lorem ipsum dolor")),
 		li(a({ class: 'pills-nav-pill' }, "Lorem ipsum")),


### PR DESCRIPTION
It's about _active_ state. Currently it's:

``` html
<li><a class="pills-nav-pill pills-nav-pill-active">Lorem ipsum dolor amet</a></li>
```

While it should be more like:

``` html
<li class="pills-nav-active"><a class="pills-nav-pill">Lorem ipsum dolor amet</a></li>
```

It gives better customisation possibility, and for JS handling, refering to active `<li>` and not `<a>` which should be found in `<li>` is way more straightforward.

Also state class would be better as `pills-nav-active`
