### PR TITLE
Full name in header is not reactive

### DIFF
--- a/view/user-base.js
+++ b/view/user-base.js
@@ -12,7 +12,7 @@ exports.menu = function () {
 	li(
 		a(
 			{ href: '/profile/' },
-			span({ class: 'header-top-user-name' }, this.user.fullName)
+			span({ class: 'header-top-user-name' }, this.user._fullName)
 		)
 	);
 	li(


### PR DESCRIPTION
When person changes name in profile form it is not updated heading.

It's beacuse `this.user.fullName` is not inserted reactively `this.user._fullName`
