### PR TITLE
Payment receipts document links are the same for each receipt.

### DIFF
--- a/view/_business-process-documents-and-data.js
+++ b/view/_business-process-documents-and-data.js
@@ -68,7 +68,7 @@ module.exports = function (businessProcess) {
 								td(receipt.document.label);
 								td({ class: 'submitted-user-data-table-issue-date' }, receipt.document._issueDate);
 								td({ class: 'submitted-user-data-table-link' },
-									a({ href: '/receipt/' + receipt.document.key + "/" },
+									a({ href: '/receipt/' + receipt.key + "/" },
 										span({ class: 'fa fa-search' }, _("Go to"))));
 							}
 						)


### PR DESCRIPTION
It's always `/receipt/document/`.
