### PR TITLE
Incorrenct table section statuses resolution

### DIFF
--- a/view/dbjs/form-entities-table-to-dom.js
+++ b/view/dbjs/form-entities-table-to-dom.js
@@ -67,9 +67,10 @@ module.exports = Object.defineProperty(db.FormEntitiesTable.prototype, 'toDOMFor
 			ns._if(gtOrEq(self.progressRules.invalid._size, 1),
 				div({ class: 'entities-overview-info' },
 					ns._if(eq(self.progressRules.invalid._size, 1),
-						function () {
-							return p(_d(self.progressRules.invalid.first._message, translationInserts));
-						},
+						self.progressRules.invalid._first.map(function (rule) {
+							if (!rule) return;
+							return p(_d(rule.message, translationInserts));
+						}),
 						ul(self.progressRules.invalid,
 							function (rule) {
 								return ns.li(_d(rule.message, translationInserts));


### PR DESCRIPTION
I approached follwing weird state in solvency:

![screen shot 2015-08-11 at 11 47 07](https://cloud.githubusercontent.com/assets/122434/9194883/d1b1f046-401e-11e5-81ba-8c921df8c528.png)

Status for valid rule is shown, but what's not shown is status for rule which informs that entities data is incimplete
