### PR TITLE
Status cell in table misses padding

### DIFF
--- a/css/components/entities-overview.css
+++ b/css/components/entities-overview.css
@@ -46,6 +46,7 @@
 	font-weight: bold;
 	display: block;
 	text-align: center;
+	padding: 0 10px;
 }
 
 .entities-overview-table .completed .status-complete {


### PR DESCRIPTION
When content is tight it appears as:

![screen shot 2015-08-11 at 10 32 38](https://cloud.githubusercontent.com/assets/122434/9193527/60f4b50a-4014-11e5-9e04-8528eec9251a.png)

It should have some padding guaranteed
