### PR TITLE
Allow override of label for table columns

### DIFF
--- a/model/form-tabular-entity.js
+++ b/model/form-tabular-entity.js
@@ -9,6 +9,7 @@ module.exports = memoize(function (db) {
 	validDb(db);
 	StringLine = defineStringLine(db);
 	return db.Object.extend('FormTabularEntity', {
+		label: { type: StringLine },
 		propertyName: { type: StringLine, required: true },
 		desktopOnly: { type: db.Boolean, value: false },
 		mobileOnly: { type: db.Boolean, value: false }

--- a/view/dbjs/form-entities-table-to-dom.js
+++ b/view/dbjs/form-entities-table-to-dom.js
@@ -85,10 +85,10 @@ module.exports = Object.defineProperty(db.FormEntitiesTable.prototype, 'toDOMFor
 						ns.tr(ns.list(this.entities, function (entity) {
 							return ns.th({ class: ns._if(entity._desktopOnly, 'desktop-only',
 										ns._if(entity._mobileOnly, 'mobile-only')) },
-									resolvePropertyPath(
+									or(entity._label, resolvePropertyPath(
 									collectionType.prototype,
 									entity.propertyName
-								).descriptor.label);
+								).descriptor.label));
 						}), ns.th(),
 							ns.th({ class: 'actions' }))
 					),


### PR DESCRIPTION
It'll be great to have `label` property on `FormTabularEntity.prototype`, which should fallback to label of property descriptor, but which we can override when configuring the form section.

Then we should make use of that label here -> https://github.com/egovernment/eregistrations/blob/master/view/dbjs/form-entities-table-to-dom.js#L88-L91
