### PR TITLE
Fix Print views

### DIFF
--- a/css/print-base.css
+++ b/css/print-base.css
@@ -1,5 +1,6 @@
 ::root {
 	--desktop-width: 1070px;
+	--light-inner-border: #e3e3e3;
 
 	/* Theme colors virables */
 	--white-background: #ffffff;

--- a/prototype/client/css-print.index
+++ b/prototype/client/css-print.index
@@ -6,3 +6,5 @@
 ../../css/components/print-user-history.css
 ../../css/components/print-user-data.css
 ../../css/components/label-reg.css
+../../css/components/section-primary.css
+../../css/components/entity-data-section-primary.css


### PR DESCRIPTION
/cc @mtuchowski 

There was an issue with server renderer configuration, which caused normal application styles to be loaded on print pages.
I've fixed that issue, but now, those pages doesn't look good. We should assure that all pages have needed styles loaded via just  `prototype-print.css`.

e.g. Data print page looked as:

![screen shot 2015-08-13 at 15 08 54](https://cloud.githubusercontent.com/assets/122434/9250549/33ae6c2e-41ce-11e5-85ae-38785997fe79.png)

Now looks as:

![screen shot 2015-08-13 at 15 13 48](https://cloud.githubusercontent.com/assets/122434/9250551/3d75e2e6-41ce-11e5-864e-7e2de765d898.png)
