### PR TITLE
Error while parsing template markdown in pdf-to-html.

### DIFF
--- a/server/html-to-pdf.js
+++ b/server/html-to-pdf.js
@@ -31,7 +31,7 @@ module.exports = function (htmlPath, pdfPath/*, options*/) {
 			root: 'file://' + dirname(htmlPath) + '/',
 			_: _,
 			e: encode,
-			md: md2Html
+			md: function (str) { return md2Html(String(str)); }
 		});
 		delete options.templateInserts;
 		return htmlToPdf.create(resolveTemplate(htmlTemplate, inserts),


### PR DESCRIPTION
``` console
TypeError: Unable to resolve expression:
    args: "_, e, md, inserts, root"
    body: " md(_(\"Company with NIT **${ nitNumber }** is:\", inserts)) "
    error: TypeError: undefined is not a function
    at ParserBlock.parse (/home/quantum/Projects/eregistrations-salvador/node_modules/remarkable/lib/parser_block.js:127:13)
    at Array.block (/home/quantum/Projects/eregistrations-salvador/node_modules/remarkable/lib/rules_core/block.js:15:17)
    at Core.process (/home/quantum/Projects/eregistrations-salvador/node_modules/remarkable/lib/parser_core.js:50:13)
    at Remarkable.parse (/home/quantum/Projects/eregistrations-salvador/node_modules/remarkable/lib/index.js:138:13)
    at Remarkable.render (/home/quantum/Projects/eregistrations-salvador/node_modules/remarkable/lib/index.js:152:36)
    at module.exports (/home/quantum/Projects/eregistrations-salvador/node_modules/i18n2-md-to-dom/lib/md-to-html.js:7:48)
    at eval (eval at <anonymous> (/home/quantum/Projects/eregistrations-salvador/node_modules/es6-template-strings/resolve.js:21:15), <anonymous>:3:10)
    at /home/quantum/Projects/eregistrations-salvador/node_modules/es6-template-strings/resolve.js:27:20
    at Array.map (native)
```
