### PR TITLE
Allow sending emails for nested business processes (BusinessProcessUpdate from Lomas)

### DIFF
--- a/server/notifications.js
+++ b/server/notifications.js
@@ -27,11 +27,20 @@ getFrom = function (user, from) {
 };
 
 getTo = function (user, to) {
+	var previousBusinessProcess = user.previousBusinessProcess;
+
 	if (to != null) {
 		if (typeof to === 'function') return to(user);
 		return to;
 	}
-	if (user.user) return user.user.email; // Fix in case of businessProcesses
+	if (user.user) return user.user.email;
+	while (previousBusinessProcess) {
+		if (previousBusinessProcess.previousBusinessProcess) {
+			previousBusinessProcess = previousBusinessProcess.previousBusinessProcess;
+		} else {
+			return previousBusinessProcess.user.email;
+		}
+	}
 	if (user.email) return user.email;
 	if (user.manager) return user.manager.email;
 };


### PR DESCRIPTION
Currently the system does not handle `previousBusinessProcess` field.

As described in https://github.com/egovernment/eregistrations-lomas/issues/964.
