### PR TITLE
Error in uploads-status-log while deleting business process.

### DIFF
--- a/server/uploads-status-log.js
+++ b/server/uploads-status-log.js
@@ -14,6 +14,8 @@ module.exports = function (db) {
 		if (endsWith.call(id, 'submissionForms/isAffidavitSigned')) {
 			bp = event.object.master;
 			nextTick(function () {
+				if (!bp.requirementUploads || !bp.paymentReceiptUploads) return;
+
 				++db._postponed_;
 				bp.requirementUploads.applicable.forEach(function (ru) {
 					if (ru.status) return;


### PR DESCRIPTION
``` javascript
  db persistent delete 4u0mceopxzj 1443777265131588
/home/quantum/Projects/eregistrations-salvador/node_modules/eregistrations/server/uploads-status-log.js:18
                bp.requirementUploads.applicable.forEach(function (ru) {
                                     ^

TypeError: Cannot read property 'applicable' of undefined
    at /home/quantum/Projects/eregistrations-salvador/node_modules/eregistrations/server/uploads-status-log.js:18:26
    at doNTCallback0 (node.js:407:9)
    at process._tickCallback (node.js:336:13)
```
