### PR TITLE
Enhance behavior of tabular section with resolvent and error message

### DIFF
--- a/view/dbjs/form-entities-table-to-dom.js
+++ b/view/dbjs/form-entities-table-to-dom.js
@@ -62,18 +62,18 @@ module.exports = Object.defineProperty(db.FormEntitiesTable.prototype, 'toDOMFor
 				method: 'post'
 			}, resolvent.formResolvent, ns.p({ class: 'submit' },
 				ns.input({ type: 'submit', value: _("Submit") }))) : undefined,
-
-			ns._if(gtOrEq(self.progressRules.invalid._size, 1),
-				div({ class: 'entities-overview-info' },
-					ns._if(eq(self.progressRules.invalid._size, 1),
-						p(self.progressRules.invalid._first.map(function (rule) {
-							if (!rule) return;
-							return _d(rule.message, translationInserts);
-						})),
-						ul(self.progressRules.invalid,
-							function (rule) {
-								return ns.li(_d(rule.message, translationInserts));
-							})))),
+			ns._if(not(self._isUnresolved),
+				ns._if(gtOrEq(self.progressRules.invalid._size, 1),
+					div({ class: 'entities-overview-info' },
+						ns._if(eq(self.progressRules.invalid._size, 1),
+							p(self.progressRules.invalid._first.map(function (rule) {
+								if (!rule) return;
+								return _d(rule.message, translationInserts);
+							})),
+							ul(self.progressRules.invalid,
+								function (rule) {
+									return ns.li(_d(rule.message, translationInserts));
+								}))))),
 
 			ns.div({ class: 'entities-overview-table-wrapper', id: resolvent.affectedSectionId },
 				ns.table(


### PR DESCRIPTION
The error messages shouldn't have been shown unless the section is resolved.
