### PR TITLE
Documents render as certificates while they should not.

### DIFF
--- a/model/document.js
+++ b/model/document.js
@@ -46,7 +46,7 @@ module.exports = memoize(function (db) {
 		number: { type: StringLine, label: _("Number") },
 		// True if this document is used as a certificate
 		isCertificate: { type: db.Boolean, value: function (_observe) {
-			return _observe(this.master.certificates.applicable).has(this);
+			return this.owner === this.master.certificates.map;
 		} }
 	}, {
 		// Document label

--- a/view/_user-business-process-documents-list.js
+++ b/view/_user-business-process-documents-list.js
@@ -22,7 +22,7 @@ module.exports = function (documents) {
 				documents, function (doc) {
 					tr(
 						td({ class: 'submitted-user-data-table-status' },
-							_if(doc._isCertificate, span({ class: 'fa fa-certificate' }))),
+							doc.isCertificate ? span({ class: 'fa fa-certificate' }) : null),
 						td(doc._label),
 						td(doc._issuedBy.map(resolveIssuer)),
 						td({ class: 'submitted-user-data-table-date' }, doc._issueDate),


### PR DESCRIPTION
In documents list for business process in myaccount, document display as certificate despite not being used as one for given process.
