### PR TITLE
Signed form, reset status after new files are uploaded

### DIFF
--- a/model/documents/signed-data-forms.js
+++ b/model/documents/signed-data-forms.js
@@ -22,6 +22,11 @@ module.exports = memoize(function (db) {
 					lastEditStamp = Math.max(lastEditStamp, _observe(section._lastEditStamp));
 				}, this);
 
+				_observe(this.files.ordered).forEach(function (file) {
+					lastEditStamp = Math.max(lastEditStamp,
+						_observe(file.getDescriptor('path').lastModified));
+				});
+
 				// If any section has been modified later than
 				// isUpToDateByUser, the user value must be invalidated.
 				return lastEditStamp < _observe(this._isUpToDateByUser._lastModified);


### PR DESCRIPTION
Therefore we shoud also take into account modification date of `file.path` property of each file.

Originaly reported at: https://github.com/egovernment/eregistrations-salvador/issues/1152
