### PR TITLE
get-soap-client should not memoize if there was an error.

### DIFF
--- a/utils/get-soap-client.js
+++ b/utils/get-soap-client.js
@@ -41,6 +41,6 @@ var getSoapClientImpl = memoize(function (wsdlUrl, soapUrl) {
 
 module.exports = function (wsdlUrl, soapUrl) {
 	return getSoapClientImpl(wsdlUrl, soapUrl).aside(null, function (err) {
-		getSoapClientImpl.clear();
+		getSoapClientImpl.clear(wsdlUrl, soapUrl);
 	});
 };


### PR DESCRIPTION
As described here: https://github.com/egovernment/eregistrations-salvador/pull/1194.
