### PR TITLE
Don't enable zoom if the picture is smaller than display area.

### DIFF
--- a/server/generate-thumb-and-preview.js
+++ b/server/generate-thumb-and-preview.js
@@ -29,11 +29,11 @@ module.exports = function (file) {
 
 	processFullPath = resolve(path, processPath);
 	thumbFullPath = resolve(path, thumbPath);
-	thumb = gm(processFullPath).density(300, 300).resize(500, 500).writeP(thumbFullPath);
+	thumb = gm(processFullPath).density(300, 300).resize(500, 500, '>').writeP(thumbFullPath);
 
 	if (file.path !== previewPath) {
 		previewFullPath = resolve(path, previewPath);
-		preview = gm(processFullPath).density(300, 300).resize(1500, 1500).writeP(previewFullPath);
+		preview = gm(processFullPath).density(300, 300).resize(1500, 1500, '>').writeP(previewFullPath);
 	}
 
 	return deferred(thumb, preview)(function () {


### PR DESCRIPTION
In upload preview widget, zoom on mouse over effect is enabled even for images smaller than widget display area. It should be disabled.

![snapshot1](https://cloud.githubusercontent.com/assets/8456055/8326255/2a0047e6-1a60-11e5-8d9d-9b216b8285c5.png)
