### PR TITLE
Client env generator script

### DIFF
--- a/scripts/generate-client-env.js
+++ b/scripts/generate-client-env.js
@@ -1,13 +1,18 @@
 'use strict';
 
-var debug     = require('debug-ext')('setup')
-  , writeFile = require('fs2/write-file')
+var ensureObject = require('es5-ext/object/valid-object')
+  , ensureString = require('es5-ext/object/validate-stringifiable-value')
+  , debug        = require('debug-ext')('setup')
+  , resolve      = require('path').resolve
+  , writeFile    = require('fs2/write-file')
 
   , stringify = JSON.stringify
   , writeOpts = { intermediate: true };
 
-module.exports = function (env, path) {
+module.exports = function (env, root) {
 	var content, clientEnv;
+	ensureObject(env);
+	root = ensureString(root);
 	debug('generate-client-env');
 	clientEnv = {
 		static: { host: (env.static && env.static.host) || '/' },
@@ -17,5 +22,5 @@ module.exports = function (env, path) {
 	if (env.googleAnalytics) clientEnv.googleAnalytics = env.googleAnalytics;
 	content = '\'use strict\';\n\nmodule.exports = require(\'mano\').env = ' +
 		stringify(clientEnv, null, '\t') + ';\n';
-	return writeFile(path, content, writeOpts);
+	return writeFile(resolve(root, 'apps-common/client/env.js'), content, writeOpts);
 };


### PR DESCRIPTION
It would be good to have it here. It will also ensure compatibility with server side env.json (via assigning its value to `mano.env`).

Tested in Guatemala, works great (will be followed with PR in guatemala that adapts it)
