### PR TITLE
Add default legacy date-controls order and labels to project and update app generator to use it.

### DIFF
--- a/client/legacy/date-controls.js
+++ b/client/legacy/date-controls.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dateControls = require('mano-legacy/live/date-controls');
+
+dateControls.order = ['d', 'm', 'y'];
+dateControls.labels = { year: 'AAAA', month: 'MM', day: 'DD' };

--- a/scripts/generate-app/templates/client/legacy/index.js/business-process.tpl
+++ b/scripts/generate-app/templates/client/legacy/index.js/business-process.tpl
@@ -10,5 +10,6 @@ $.legacyDb = require('./${ appName }-legacy-proto');
 
 require('mano-legacy/live/input-mask');
 require('eregistrations/client/legacy/refresh-guide');
+require('eregistrations/client/legacy/date-controls');
 require('mano-legacy/dbjs-observe-mock');
 require('mano-legacy/hash-nav-modal');


### PR DESCRIPTION
As requested here: https://github.com/egovernment/eregistrations-guatemala/pull/365#discussion-diff-45448625
