### PR TITLE
Legacy refresh-guide should check if getter is a function.

### DIFF
--- a/client/legacy/refresh-guide.js
+++ b/client/legacy/refresh-guide.js
@@ -160,8 +160,14 @@ module.exports = $.refreshGuide = function (guideFormId, businessProcessId,
 
 		// Resolve each registration certificates, requirements and costs
 		businessProcess.registrations.map.forEach(function (registration) {
-			registration.certificates = $.setify(registration.certificates($.dbjsObserveMock));
-			registration.requirements = $.setify(registration.requirements($.dbjsObserveMock));
+			registration.certificates =
+					typeof registration.certificates === 'function' ?
+						$.setify(registration.certificates($.dbjsObserveMock))
+							: registration.certificates;
+			registration.requirements =
+					typeof registration.requirements === 'function' ?
+						$.setify(registration.requirements($.dbjsObserveMock))
+							: registration.requirements;
 			registration.costs =
 					typeof registration.costs === 'function' ?
 						$.setify(registration.costs($.dbjsObserveMock)) : registration.costs;


### PR DESCRIPTION
``` JavaScript
Uncaught TypeError: registration.requirements is not a function
(anonymous function) @ :9003/business-process-company.legacy.js:368
(anonymous function) @ :9003/business-process-company.legacy.js:1367
module.exports.$.forIn @ :9003/business-process-company.legacy.js:1731
module.exports.$.dbjsMapForEach @ :9003/business-process-company.legacy.js:1365
anonymous @ :9003/business-process-company.legacy.js:529
(anonymous function) @ :9003/business-process-company.legacy.js:366
run @ :9003/business-process-company.legacy.js:2819
```

Caused by this line (`registrations.requirements` is a array in this case - no requirements):

``` JavaScript
registration.requirements = $.setify(registration.requirements($.dbjsObserveMock));
```
