### PR TITLE
controls-map when no child

### DIFF
--- a/client/legacy/controls-map.js
+++ b/client/legacy/controls-map.js
@@ -93,7 +93,7 @@ module.exports = function (config) {
 			var child, parent;
 
 			child = event.newValue && event.newValue.__id__;
-			parent = deptMap[child];
+			parent = child ? deptMap[child] : '';
 
 			if (selectedParentOption) {
 				selectedParentOption.removeAttribute('selected');
@@ -103,7 +103,7 @@ module.exports = function (config) {
 				selectedParentOption.setAttribute('selected', 'selected');
 			}
 			parentSelect.value = parent;
-			updateSelect(parent);
+			updateSelect();
 
 			if (selectedDeptOption) selectedDeptOption.removeAttribute('selected');
 			selectedDeptOption = options[child];


### PR DESCRIPTION
There's one bug, it looks that parent control does not reset selected value, after saved value is deleted.

Save some value
Check "Choose.." on child control and save.
Expected is that parent also goes to "Choose" after save, currently it goes back to parent value of previously saved child, which is not right
