### PR TITLE
Wrong Cost.step defined in generated legacy mock database.

### DIFF
--- a/scripts/generate-legacy-dbjs-mock.js
+++ b/scripts/generate-legacy-dbjs-mock.js
@@ -5,19 +5,15 @@
 var ensureType     = require('dbjs/valid-dbjs-type')
   , serialize      = require('es5-ext/object/serialize')
   , writeFile      = require('fs2/write-file')
-  , defineCurrency = require('dbjs-ext/number/currency')
-  , defineCost     = require('eregistrations/model/cost')
   , toArray        = require('es5-ext/array/to-array');
 
 var defineForEach = function (object) {
 	object.forEach = new Function('cb, thisArg', '$.dbjsMapForEach(this, cb, thisArg);');
 };
 
-module.exports = function (businessProcessType, filename/*, options*/) {
+module.exports = function (BusinessProcessType, filename/*, options*/) {
 	var options       = Object(arguments[2])
-	  , db            = businessProcessType.database
-	  , Cost          = defineCost(db)
-	  , Currency      = defineCurrency(db)
+	  , db            = BusinessProcessType.database
 	  , legacyDb      = {}
 	  , certificates  = {}
 	  , costs         = {}
@@ -27,10 +23,10 @@ module.exports = function (businessProcessType, filename/*, options*/) {
 	  , costType      = {}
 	  , businessProcessProto;
 
-	ensureType(businessProcessType);
+	ensureType(BusinessProcessType);
 
 	// Get BusinessProcess prototype.
-	businessProcessProto = businessProcessType.prototype;
+	businessProcessProto = BusinessProcessType.prototype;
 
 	// Get all interesting fields from BusinessProcess prototype.
 	var getPropertyValue = function (multipleProcessName, propertyName) {
@@ -83,13 +79,13 @@ module.exports = function (businessProcessType, filename/*, options*/) {
 	requirements.applicable  = getPropertyValue('requirements', 'applicable');
 
 	// Copy less interesting (support) stuff also.
-	currencyType.format = Currency.format;
-	currencyType.symbol = Cost.prototype.getDescriptor('amount').type.symbol;
-	currencyType.isoCode = Cost.prototype.getDescriptor('amount').type.isoCode;
-	costType.step = Cost.prototype.getDescriptor('amount').step;
+	currencyType.format = db.Currency.format;
+	currencyType.symbol = db.Cost.prototype.getDescriptor('amount').type.symbol;
+	currencyType.isoCode = db.Cost.prototype.getDescriptor('amount').type.isoCode;
+	costType.step = db.Cost.prototype.getDescriptor('amount').step;
 
 	// Add everything to legacyDb
-	legacyDb[businessProcessType.__id__] = {
+	legacyDb[BusinessProcessType.__id__] = {
 		prototype: {
 			certificates: certificates,
 			costs: costs,


### PR DESCRIPTION
In system:

``` javascript
Cost.prototype.getDescriptor('amount').step = 0.01;
```

In generated mock database:

``` javascript
...
            }
            return (options.prefix || '') + result + (options.postfix || '');
        },"symbol":"Q","isoCode":"GTQ"},"Cost":{"step":1}};
```
