### PR TITLE
Configure new handling for business process table print view

### DIFF
--- a/view/print-business-processes-table.js
+++ b/view/print-business-processes-table.js
@@ -1,16 +1,88 @@
 'use strict';
 
-var toNatural  = require('es5-ext/number/to-pos-integer')
+var ensureArray   = require('es5-ext/array/valid-array')
+  , toNatural     = require('es5-ext/number/to-pos-integer')
+  , ensureObject  = require('es5-ext/object/valid-object')
+  , hyphenToCamel = require('es5-ext/string/#/hyphen-to-camel')
+  , replaceContent = require('dom-ext/element/#/replace-content')
+  , mano       = require('mano')
   , location   = require('mano/lib/client/location')
-  , _          = require('mano').i18n.bind('Print')
+  , Manager = require('./components/business-processes-table/manager')
   , arrayToSet = require('../utils/array-to-set')
   , findKey    = require('es5-ext/object/find-key')
 
-  , keys = Object.keys, ceil = Math.ceil;
+  , keys = Object.keys, ceil = Math.ceil
+  , env = mano.env, _ = mano.i18n;
+
+var setupQueryHandler =
+	require('eregistrations/view/components/business-processes-table/setup-query-handler');
 
 exports._parent = require('./print-base');
 
-exports.main = function () {
+var generateMainContent = function () {
+	var statusMap = ensureObject(exports._statusMap())
+	  , columns = ensureArray(exports._columns())
+	  , roleName = hyphenToCamel.call(this.appName.slice('official-'.length))
+	  , container, superIsExernalQuery;
+
+	var listManager = new Manager({
+		user: this.user,
+		roleName: roleName,
+		statusMap: statusMap,
+		getOrderIndex: exports._getOrderIndex,
+		itemsPerPage: env.objectsListItemsPerPage
+	});
+	superIsExernalQuery = listManager._isExternalQuery;
+	listManager._isExternalQuery = function (query) {
+		if (!query.status) return true;
+		return superIsExernalQuery.call(this, query);
+	};
+
+	var statuses = keys(statusMap).filter(function (name) { return (name !== 'all'); })
+		.sort(function (a, b) { return statusMap[a].order - statusMap[b].order; });
+
+	setupQueryHandler(listManager, '/print-business-processes-list/');
+
+	var getSection  = function (url, businessProcesses, data) {
+		return [div({ class: 'print-users-list-caption' },
+			data.label, span(" (", businessProcesses.length, ")")),
+			table({ class: 'print-users-list' },
+				thead(columns.map(function (column) { return th({ class: column.class }, column.head); })),
+				tbody({ onEmpty: tr({ class: 'empty' }, td({ colspan: columns.length },
+					_("There are no items"))) }, businessProcesses,
+					function (businessProcess) {
+						return tr(columns.map(function (column) {
+							return td({ class: column.class }, column.data(businessProcess));
+						}));
+					}))];
+	};
+
+	container = div();
+
+	listManager.on('change', function () {
+		var result = [];
+		if (listManager.pageCount > 1) {
+			result.push(p({ class: 'page' }, _("Page"), " ", listManager.page, " / ",
+				listManager.pageCount));
+		}
+		if (listManager.query.status) {
+			result.push(getSection(url, listManager.list, statusMap[listManager.query.status]));
+		} else {
+			result.push(ul(statuses, function (status) {
+				if (statusMap[status].redundant) return;
+				return getSection(url, listManager.list.filter(function (bp) {
+					return (this[bp.__id__] === status);
+				}, listManager.serverResult.statusMap), statusMap[status]);
+			}));
+		}
+		replaceContent.call(container, result);
+	});
+
+	return container;
+};
+
+// Legacy generator (to be removed once ELS is migrated to new data handling)
+var legacyGenerateMainContent = function () {
 	var statusMap = exports._statusMap(this)
 	  , perPage = exports._cacheLimits(this).usersPerPage;
 
@@ -76,9 +148,20 @@ exports.main = function () {
 		}));
 };
 
+exports.main = function () {
+	if (exports._businessProcessesTable !== Function.prototype) {
+		return legacyGenerateMainContent.apply(this, arguments);
+	}
+	return generateMainContent.apply(this, arguments);
+};
+
 exports['print-page-title'] = function () { insert(this.processingStep.label); };
 
-exports._businessProcessesTable = Function.prototype;
 exports._statusMap = Function.prototype;
+exports._getOrderIndex = Function.prototype;
+exports._columns = Function.prototype;
+
+// Legacy extensions (to be removed once ELS is migrated to new data handling)
+exports._businessProcessesTable = Function.prototype;
 exports._defaultSort = Function.prototype;
 exports._cacheLimits = Function.prototype;


### PR DESCRIPTION
So far it supported only old (ELS) way, this update brings support for new table manager based (scalable) handling, as we configure it new system, and as it's used already in LDZ.

Legacy code was left as an option, as it's still used by ELS system. It'll be removed as soon as ELS gets scalability configuration.

This change was tested in both TZ and ELS systems, both configuration modes are confirmed to work as expected
