### PR TITLE
Ensure proper promise error exposure in view routing

### DIFF
--- a/prototype/client/program.js
+++ b/prototype/client/program.js
@@ -59,11 +59,13 @@ router = new SiteTreeRouter(require('../routes'), siteTree, {
 		processingStep: db.firstBusinessProcess.processingSteps.map.revision  }
 });
 appLocation.on('change', function () {
+	var result;
 	if (last.call(appLocation.pathname) !== '/') {
 		appLocation.goto(appLocation.pathname + '/' + appLocation.search + appLocation.hash);
 		return;
 	}
-	router.route(appLocation.pathname);
+	result = router.route(appLocation.pathname);
+	if (result && (typeof result.done === 'function')) result.done();
 });
 appLocation.onchange();
 

--- a/scripts/generate-app/templates/client/program.js/authenticated.tpl
+++ b/scripts/generate-app/templates/client/program.js/authenticated.tpl
@@ -118,11 +118,13 @@ loadView = function () {
 	}
 
 	appLocation.on('change', refresh = function () {
+		var result;
 		if (last.call(appLocation.pathname) !== '/') {
 			appLocation.goto(appLocation.pathname + '/' + appLocation.search + appLocation.hash);
 			return;
 		}
-		siteTreeRouter.route(appLocation.pathname);
+		result = siteTreeRouter.route(appLocation.pathname);
+		if (result && (typeof result.done === 'function')) result.done();
 	});
 	if (appLocation.pathname) refresh();
 	else appLocation.onchange();

--- a/scripts/generate-app/templates/client/program.js/business-process.tpl
+++ b/scripts/generate-app/templates/client/program.js/business-process.tpl
@@ -120,11 +120,13 @@ loadView = function () {
 	}
 
 	appLocation.on('change', refresh = function () {
+		var result;
 		if (last.call(appLocation.pathname) !== '/') {
 			appLocation.goto(appLocation.pathname + '/' + appLocation.search + appLocation.hash);
 			return;
 		}
-		siteTreeRouter.route(appLocation.pathname);
+		result = siteTreeRouter.route(appLocation.pathname);
+	if (result && (typeof result.done === 'function')) result.done();
 	});
 	if (appLocation.pathname) refresh();
 	else appLocation.onchange();

--- a/scripts/generate-app/templates/client/program.js/official.tpl
+++ b/scripts/generate-app/templates/client/program.js/official.tpl
@@ -119,11 +119,13 @@ loadView = function () {
 	}
 
 	appLocation.on('change', refresh = function () {
+		var result;
 		if (last.call(appLocation.pathname) !== '/') {
 			appLocation.goto(appLocation.pathname + '/' + appLocation.search + appLocation.hash);
 			return;
 		}
-		siteTreeRouter.route(appLocation.pathname);
+		result = siteTreeRouter.route(appLocation.pathname);
+		if (result && (typeof result.done === 'function')) result.done();
 	});
 	if (appLocation.pathname) refresh();
 	else appLocation.onchange();

--- a/scripts/generate-app/templates/client/program.js/public.tpl
+++ b/scripts/generate-app/templates/client/program.js/public.tpl
@@ -79,11 +79,13 @@ viewTree = new SiteTree(document, require('../view/inserts'),
 router = new SiteTreeRouter(require('../routes'), viewTree,
 	{ notFound: require('../view').notFound });
 appLocation.on('change', refresh = function () {
+	var result;
 	if (last.call(appLocation.pathname) !== '/') {
 		appLocation.goto(appLocation.pathname + '/' + appLocation.search + appLocation.hash);
 		return;
 	}
-	router.route(appLocation.pathname);
+	result = router.route(appLocation.pathname);
+	if (result && (typeof result.done === 'function')) result.done();
 });
 if (appLocation.pathname) refresh();
 else appLocation.onchange();

--- a/scripts/generate-app/templates/client/program.js/user.tpl
+++ b/scripts/generate-app/templates/client/program.js/user.tpl
@@ -119,11 +119,13 @@ loadView = function () {
 	}
 
 	appLocation.on('change', refresh = function () {
+		var result;
 		if (last.call(appLocation.pathname) !== '/') {
 			appLocation.goto(appLocation.pathname + '/' + appLocation.search + appLocation.hash);
 			return;
 		}
-		siteTreeRouter.route(appLocation.pathname);
+		result = siteTreeRouter.route(appLocation.pathname);
+		if (result && (typeof result.done === 'function')) result.done();
 	});
 	if (appLocation.pathname) refresh();
 	else appLocation.onchange();


### PR DESCRIPTION
If view route `match` function resulted with promise, and that promise was rejected, errors were not seen.
