### PR TITLE
Invalid reference in official controller

### DIFF
--- a/routes/official.js
+++ b/routes/official.js
@@ -72,7 +72,7 @@ module.exports = function (step) {
 					var certificate =
 						this.businessProcess.certificates.map.get(hyphenToCamel.call(certificateKey));
 					if (!certificate) return false;
-					if (!this.processingStep.certificates.applicable.has(certificate)) {
+					if (!this.processingStep.certificates.uploaded.has(certificate)) {
 						return false;
 					}
 


### PR DESCRIPTION
Here we use property `applicable` which does not exist:
https://github.com/egovernment/eregistrations/blob/master/routes/official.js#L75
