### PR TITLE
Improving the pills-nav-pill of meta-admin panel

### DIFF
--- a/css/components/pills-nav.css
+++ b/css/components/pills-nav.css
@@ -21,6 +21,7 @@
 	margin: 0 11px;
 	line-height: 44px;
 	border-radius: 5px;
+	font-size: 16px;
 	text-decoration: none;
 }
 .pills-nav-pill:hover,
@@ -33,6 +34,6 @@
 .pills-nav-active > a:hover,
 .pills-nav-active > a:focus,
 .pills-nav-active > a:active {
-	background: var(--normal-background);
-	color: var(--white-text);
+	background: var(--normal-dark-background);
+	color:var(--white-text);
 }

--- a/css/components/user-forms.css
+++ b/css/components/user-forms.css
@@ -5,6 +5,9 @@
 .user-forms > *:first-child {
 	margin-top: 44px;
 }
+.user-forms > .pills-nav {
+	margin-top: 22px;
+}
 .user-forms > form,
 .user-forms > .disabler-range,
 .user-forms > .disabler-range > .disabler-range,


### PR DESCRIPTION
Now that we are working on proto, I suggest we improve the tabs that are in the meta-admin panels or similar (like dispatcher in tanzania). 

You can see it with : 
tanzania : vianouche@gmail.com abc123
gt : meta@eregistrations.org abc123
els: meta-admin@eregistrations.org abc123

I see 3 things that we could do : 
1. spacing with submitted-menu : in els, the spacing is perfect,  in tz and gt, the tabs are too low: 
   ![miempresa_gob_sv](https://cloud.githubusercontent.com/assets/3383078/12480514/3d077aa6-c043-11e5-9ccd-4d000321afa8.jpg)
2. the background of the active tab could have the same background than the active item on submitted-menu. (or if you prefer it could have the colour of the background of submitted-menu)
3. the size of the fonts could be the same than the fonts in submitted-menu  (here 16px)

i hope that 3 does not break VR, if so discard this.
