### PR TITLE
Resolve lastModified only when necessary

### DIFF
--- a/view/_business-process-table-columns.js
+++ b/view/_business-process-table-columns.js
@@ -83,7 +83,9 @@ exports.columns = [{
 	data: function (businessProcess) {
 		var isSubmitted = businessProcess._isSubmitted;
 
-		return _if(isSubmitted, isSubmitted._lastModified.map(formatLastModified));
+		return _if(isSubmitted, function () {
+			return isSubmitted._lastModified.map(formatLastModified);
+		});
 	}
 }, {
 	head: _("Withdraw date"),
@@ -91,7 +93,9 @@ exports.columns = [{
 	data: function (businessProcess) {
 		var isApproved = businessProcess._isApproved;
 
-		return _if(isApproved, isApproved._lastModified.map(formatLastModified));
+		return _if(isApproved, function () {
+			return isApproved._lastModified.map(formatLastModified);
+		});
 	}
 }, {
 	head: _("Inscriptions and controls"),


### PR DESCRIPTION
Table generation got slow due to non-optimal lastModified resolution from getters.

In close future those values will be static, until then we fix the issue by resolving them only when we're sure date should be resolved.
