### PR TITLE
Data : add "Registers numbers" section in the data form

### DIFF
--- a/view/_business-process-documents-and-data.js
+++ b/view/_business-process-documents-and-data.js
@@ -93,6 +93,7 @@ var drawCertificatesPart = function (target, urlPrefix) {
 						th(_("Name")),
 						th(_("Issuer")),
 						th({ class: 'submitted-user-data-table-date' }, _("Issue date")),
+						th(_("Number")),
 						th({ class: 'submitted-user-data-table-link' })
 					)
 				),
@@ -104,6 +105,7 @@ var drawCertificatesPart = function (target, urlPrefix) {
 						td(certificate.label);
 						td(certificate._issuedBy);
 						td({ class: 'submitted-user-data-table-date' }, certificate._issueDate);
+						td(certificate._number);
 						td({ class: 'submitted-user-data-table-link' },
 							a({ href: urlPrefix + 'certificate/' +
 								camelToHyphen.call(certificate.key) + '/' },


### PR DESCRIPTION
![miempresa_gob_sv](https://cloud.githubusercontent.com/assets/3383078/12205564/d7817b02-b63b-11e5-8915-eccbcd29c56e.jpg)

In the data of the file, we would like to add a new section "Registers numbers" that would contain the given numbers of the registers asked by the user. 
This section would be seen after revision by all the institutions and only after withdrawal by the user (exactly like the certificates in the file). 

The section will be filled along the process with the given certificates numbers.

We would like this section to be at the top of the data.
