### PR TITLE
Fix behavior of incomplete-form-nav when section has no label

### DIFF
--- a/view/components/incomplete-form-nav.js
+++ b/view/components/incomplete-form-nav.js
@@ -26,12 +26,12 @@ var sectionLabel = function (formSection, level) {
 	if (level === 0) return missingFieldsLabel();
 
 	if (formSection.label) {
-		title = "In _\"${ sectionLabel }\"_ section:";
+		title = _("In _\"${ sectionLabel }\"_ section:", { sectionLabel: formSection.label });
 	} else {
-		title = "In main section:";
+		title = _("In main section:");
 	}
 	return p({ class: 'section-warning-missing-fields-sub-' + 1 },
-		mdi(_d(title, { sectionLabel: formSection.label })));
+		mdi(title));
 };
 
 var missingPropertiesList = function (formSection) {


### PR DESCRIPTION
Right now when a given section has no label, we get:

`Information about the investment is incomplete
    Missing required fields:
       In "" section: "Name of the project"`

I'm not sure how we want to go about it.  
