### PR TITLE
h2 in Roboto 300 is not sharp

### DIFF
--- a/css/components/user-forms.css
+++ b/css/components/user-forms.css
@@ -26,7 +26,7 @@
 }
 
 .user-forms h2 {
-	font-weight: 300;
+	font-weight: 400;
 }
 
 .user-forms .form-elements h2 {


### PR DESCRIPTION
I am on my desktop PC under chrome Version 48.0.2564.116 m (I observe the same thing on my IE11 and Firefox 39), the h2 are out as : 

tanzania:
![capture11](https://cloud.githubusercontent.com/assets/3383078/13423893/facff65c-df9d-11e5-95b8-dbf7b789ba6d.PNG)

gt:
![capture12](https://cloud.githubusercontent.com/assets/3383078/13423894/fad43744-df9d-11e5-95dc-985949210f19.PNG)

same on els. 
- Everything is fine and sharp when I put font-weight is 400
- I don't see this problem on my mac

Any ideas where this can come from? if not, let's switch to font-weight 400 please
