### PR TITLE
MyAccount : allow translation of "Download document"

### DIFF
--- a/view/_business-process-document.js
+++ b/view/_business-process-document.js
@@ -124,7 +124,7 @@ module.exports = function (doc, sideContent) {
 						download: _if(doc.files.ordered._size, _if(eq(doc.files.ordered._size, 1),
 							resolve(doc.files.ordered._first, 'path'), resolveArchivePath(doc)
 							))
-						}, "Download document"),
+						}, _("Download document")),
 					sideContent)
 				),
 			p(_("This certificate does not have any physical file attached to it."))


### PR DESCRIPTION
I do not see it, for example in gt

![capture66](https://cloud.githubusercontent.com/assets/3383078/13665880/d200ceb4-e6ae-11e5-8455-72daf6a23aec.PNG)
