### PR TITLE
Introduce 'optionalInfo' for costs

### DIFF
--- a/model/cost.js
+++ b/model/cost.js
@@ -15,8 +15,10 @@ module.exports = memoize(function (db) {
 	return db.Object.extend('Cost', {
 		// Cost label
 		label: { type: StringLine },
-		// Cost label
+		// Cost legend
 		legend: { type: StringLine },
+		// Cost optional info
+		optionalInfo: { type: StringLine },
 		// Cost amount
 		amount: { type: Currency, step: 1 },
 		// Cost's sideAmount is not taken into account in payable costs, nor in total.

--- a/view/business-process-guide.js
+++ b/view/business-process-guide.js
@@ -218,6 +218,11 @@ exports._costsList = function (context) {
 			li({ id: 'cost-li-' + camelToHyphen.call(cost.key), 'data-key': cost.key },
 				span({ class: 'user-guide-costs-list-label' },
 					span({ id: 'cost-label-' + camelToHyphen.call(cost.key) }, cost.label),
+					cost.optionalInfo && span({ class: 'input-optional-info' },
+						span({ class: 'fa fa-info-circle' }, "Info"),
+						span({ class: 'input-optional-info-content' },
+							typeof cost.optionalInfo === 'string' ? md(cost.optionalInfo)
+								: cost.optionalInfo)),
 					small(cost.legend)),
 				span({ id: 'cost-amount-' + camelToHyphen.call(cost.key) }));
 		}),


### PR DESCRIPTION
Originally requested at https://github.com/egovernment/eregistrations-salvador/issues/1238

Aside of already existing `label` and `legend` there's request to add `optionalInfo` for costs. It will be accessible via (i) aside of a cost label in costs table in a guide.

It depends on https://github.com/egovernment/eregistrations/pull/876 which should be done first
