### PR TITLE
Sworn declaration introductive text

### DIFF
--- a/css/components/user-submission.css
+++ b/css/components/user-submission.css
@@ -1,5 +1,8 @@
 .user-submission-sworn-declaration {
 	padding-bottom: 22px;
+}
+
+.user-submission-sworn-declaration label {
 	font-size: 18px;
 	font-weight: 300;
 }


### PR DESCRIPTION
related to #1235

I do not understand why we needed to change the design of the explanation text above the sworn declaration, it now has a different design compared to all the other explanation texts.

Why do we do that ?
