### PR TITLE
Vertically top align label in forms

### DIFF
--- a/css/components/entity-data-section.css
+++ b/css/components/entity-data-section.css
@@ -29,6 +29,7 @@
 	width: 50%;
 	padding: 11px 0 11px 10px;
 	text-align: left;
+	vertical-align: top;
 }
 
 .entity-data-section-entities .entity-data-section-sub table th,


### PR DESCRIPTION
Could we have the labels top-vertically aligned in the case of this example : 

![tiw](https://cloud.githubusercontent.com/assets/3383078/12259205/5d36aa12-b914-11e5-9f9c-d35014935d4c.jpg)
