### PR TITLE
Notary : client - creation : add email field hint

### DIFF
--- a/view/manager-user-create.js
+++ b/view/manager-user-create.js
@@ -20,7 +20,9 @@ exports['sub-main'] = {
 					li(field({ dbjs: user._firstName, label: _("Client's first name") })),
 					li(field({ dbjs: user._lastName, label: _("Client's last name") })),
 					li(field({ dbjs: db.Email, name: user._email.dbId,
-						label: _("Client's email") }))
+						label: _("Client's email"), hint: _("This email is optional. " +
+							"If you fill it, the client will not receive any notifications until your decide," +
+							" later, to create his/her account.") }))
 				),
 				p({ class: 'submit-placeholder' },
 					input({ type: 'submit', value: _("Save") }))


### PR DESCRIPTION
Below the email field, i would like a hint translatable text to be able to say : "This email is optionnal. If you fill it, the client will not receive any notifications until your decide, later, to create his/her account."

this will again help notaries in GT to relax about asking the email field. 

![capture156](https://cloud.githubusercontent.com/assets/3383078/13987602/a3083bc4-f108-11e5-8922-bce29561c8ca.PNG)
