### PR TITLE
Notary account : Client tab - we can remove Entity and Email columns

### DIFF
--- a/view/manager-home.js
+++ b/view/manager-home.js
@@ -26,17 +26,20 @@ exports['manager-account-content'] = function () {
 				{ class: 'submitted-user-data-table' },
 				thead(tr(
 					th(_("Client")),
-					th(_('Email')),
+					th(_('Services')),
 					th()
 				)),
 				tbody(
 					clients,
 					function (client) {
+						var bpSet = client.initialBusinessProcesses.and(this.user.managedBusinessProcesses)
+									.filterByKey('businessName');
+
 						return tr(
 							td(client._fullName),
 
-							td(span(client._email),
-								_if(client.roles._has('user'), [" ", span({ class: 'fa fa-check' })])),
+							td(bpSet.map(function (bp) { return bp.constructor; })._size),
+
 							td({ class: 'actions' },
 								_if(and(this.user._isManagerActive,
 										eq(client._manager, this.user)),


### PR DESCRIPTION
We can remove those 2 columns that add nothing to the notary account and will be source of misunderstanding in gt : 

(this change is for all the system)

![capture160](https://cloud.githubusercontent.com/assets/3383078/13992894/26b9fdb2-f11e-11e5-92e7-676b2da994ce.PNG)

Sorry for this deletion, sometimes we need to see the bad things to realize that they are bad... 
