### PR TITLE
Notary : incoherences in menu 

### DIFF
--- a/css/components/manager-bar.css
+++ b/css/components/manager-bar.css
@@ -34,6 +34,7 @@
 	background-color: var(--normal-dark-background);
 }
 
+.manager-bar-info a,
 .manager-bar .actions-create {
 	border-radius: 4px;
 	color: var(--white-text);
@@ -43,6 +44,9 @@
 	line-height: 22px;
 }
 
+.manager-bar-info a:active,
+.manager-bar-info a:focus,
+.manager-bar-info a:hover,
 .manager-bar .actions-create:active,
 .manager-bar .actions-create:focus,
 .manager-bar .actions-create:hover {


### PR DESCRIPTION
look at this : 

from clientAccount : 
![capture164](https://cloud.githubusercontent.com/assets/3383078/13994437/0b2a2cc8-f125-11e5-9af8-fa9882474f87.PNG)

from clientAccount/request 
![capture165](https://cloud.githubusercontent.com/assets/3383078/13994443/1247aecc-f125-11e5-992d-75965bc46343.PNG)

we NEED to find a way to avoid doing things like that, I am getting very tired to see this level of things.
