### PR TITLE
Notary : client name in menu should be a link, not a button

### DIFF
--- a/css/components/manager-bar.css
+++ b/css/components/manager-bar.css
@@ -35,6 +35,27 @@
 }
 
 .manager-bar-info a,
+.manager-bar-info button {
+	background: none;
+	text-decoration: underline;
+	color:var(--normal-text);
+	font-size: 14px;
+	padding: 4px 10px;
+}
+
+.manager-bar-info a:hover,
+.manager-bar-info a:active,
+.manager-bar-info a:focus,
+.manager-bar-info button:hover,
+.manager-bar-info button:active,
+.manager-bar-info button:focus {
+	background: none;
+	text-decoration: underline;
+	color:var(--dark-text);
+	font-size: 14px;
+	padding: 4px 10px;
+}
+
 .manager-bar .actions-create {
 	border-radius: 4px;
 	color: var(--white-text);
@@ -44,9 +65,6 @@
 	line-height: 22px;
 }
 
-.manager-bar-info a:active,
-.manager-bar-info a:focus,
-.manager-bar-info a:hover,
 .manager-bar .actions-create:active,
 .manager-bar .actions-create:focus,
 .manager-bar .actions-create:hover {


### PR DESCRIPTION
No action is asked from this so it should be simply a link like it used to be 

![capture174](https://cloud.githubusercontent.com/assets/3383078/14018456/2c7aece2-f1ce-11e5-83a4-b4d39d726a6e.PNG)
