### PR TITLE
Ensure proper signed form confirmation checkbox reset

### DIFF
--- a/view/dbjs/signed-form-requirement-upload-to-dom-form.js
+++ b/view/dbjs/signed-form-requirement-upload-to-dom-form.js
@@ -11,20 +11,28 @@ module.exports = Object.defineProperty(
 	d(function (document/*, options */) {
 		var opts = normalizeOptions(arguments[1]);
 		opts.afterHeader = function (requirementUpload) {
-			return [
+			var checkbox;
+			var needsConfirmation = and(requirementUpload.document.files.ordered._size,
+				not(requirementUpload.document._isUpToDate));
+			var result = [
 				div(a({ href: '/print-forms-data/', target: '_blank' },
 					_("Print your application form"))),
 				// If the printed form is uploaded and might not be up to date,
 				// the user should check the confirmation checkbox.
-				insert(_if(and(requirementUpload.document.files.ordered._size,
-						not(requirementUpload.document._isUpToDate)),
+				insert(_if(needsConfirmation,
 					p({ class: 'entities-overview-info' },
 						requirementUpload.document.getDescriptor('isUpToDateByUser').label,
 						' ',
 						label({ class: 'signed-data-form-requirement-label' },
-							input({ name: requirementUpload.document.__id__ + '/isUpToDateByUser',
-								type: 'checkbox', value: 1, checked: false }), ' ', _("Yes")))
-					))];
+							checkbox = input({ name: requirementUpload.document.__id__ + '/isUpToDateByUser',
+								type: 'checkbox', value: 1, checked: false }), ' ', _("Yes")))))
+			];
+			// Reset checkbox value at initialization and whenever we re-ask for confirmation
+			checkbox.checked = false;
+			needsConfirmation.on('change', function (event) {
+				if (event.newValue) checkbox.checked = false;
+			});
+			return result;
 		};
 
 		return db.RequirementUpload.prototype.toDOMForm.call(this, document, opts);


### PR DESCRIPTION
At this point it's strictly dependent on form reset events therefore unreliable, e.g. if event indication that files need to be reconfirmed comes from server, checkbox is revealed with `checked` state.

Whenever it's brought back again it needs to be reset. This update fixes that.

@kamsi it will also fix effect of race condition you observed
