### PR TITLE
Serve uploads through static channel

### DIFF
--- a/view/_business-process-document.js
+++ b/view/_business-process-document.js
@@ -27,8 +27,11 @@ var getFilePreview = function (file) {
 			src: url('pdfjs/web/viewer.html?file=') + file.path
 		});
 	}
-	return img({ zoomOnHover: true, src: stUrl(or(resolve(file._preview, '_url'),
-		resolve(file._thumb, '_url'))) });
+	return img({ zoomOnHover: true, src: or(resolve(file._preview, '_url'),
+		file.thumb._url.map(function (thumbUrl) {
+			if (!thumbUrl) return;
+			return stUrl(thumbUrl);
+		})) });
 };
 
 module.exports = function (doc, sideContent) {

--- a/view/components/uploaded-file.js
+++ b/view/components/uploaded-file.js
@@ -15,7 +15,10 @@ module.exports = function (observable/*, options*/) {
 	return ns._if(ns.resolve(observable, '_name'),
 		ns.div({ class: 'file-thumb' },
 			ns.a({ href: ns.resolve(observable, '_url'), target: '_blank', class: 'file-thumb-image' },
-				ns.img({ src: stUrl(ns.resolve(observable, '_thumb', '_url')) })),
+				ns.img({ src: observable.thumb._url.map(function (thumbUrl) {
+					if (!thumbUrl) return;
+					return stUrl(thumbUrl);
+				}) })),
 			ns.div({ class: 'file-thumb-actions' },
 				ns.span({ class: 'file-thumb-document-size' },
 					ns.mmap(ns.resolve(observable, '_diskSize'), resolveSize)),

--- a/view/components/uploaded-files-list.js
+++ b/view/components/uploaded-files-list.js
@@ -15,7 +15,10 @@ module.exports = function (files/*, options*/) {
 	return ns.ul({ class: 'file-uploader-items' }, files, function (file) {
 		return ns.li(ns.div({ class: 'file-thumb' },
 			ns.a({ href: file._url, target: '_blank', class: 'file-thumb-image' },
-				ns.img({ src: stUrl(ns.resolve(file._thumb, '_url')) })),
+				ns.img({ src: file.thumb._url.map(function (thumbUrl) {
+					if (!thumbUrl) return;
+					return stUrl(thumbUrl);
+				}) })),
 			ns.div({ class: 'file-thumb-actions' },
 				ns.span({ class: 'file-thumb-document-size' },
 					ns.mmap(file._diskSize, resolveSize)),

--- a/view/dbjs/submission-file.js
+++ b/view/dbjs/submission-file.js
@@ -4,7 +4,6 @@ var d        = require('d')
   , isNested = require('dbjs/is-dbjs-nested-object')
   , _if      = require('observable-value/if')
   , map      = require('observable-value/map')
-  , resolve  = require('observable-value/resolve')
   , _        = require('mano').i18n.bind("Documents")
   , db       = require('mano').db
   , docMimeTypes = require('../../utils/microsoft-word-doc-mime-types')
@@ -48,12 +47,16 @@ module.exports = Object.defineProperties(db.File, {
 
 			itemDom = _if(isValid, el('div', { class: 'file-thumb' },
 				el('a', { href: file._url, target: '_blank', class: 'file-thumb-image' },
-					el('img', { src: stUrl((function () {
+					el('img', { src: (function () {
 						if (includes.call(docMimeTypes, file.type)) {
-							return '/img/word-doc-icon.png';
+							return stUrl('/img/word-doc-icon.png');
 						}
-						return resolve(file, '_thumb', '_url');
-					}())) })),
+
+						return file.thumb._url.map(function (thumbUrl) {
+							if (!thumbUrl) return;
+							return stUrl(thumbUrl);
+						});
+					}()) })),
 				el('div', { class: 'file-thumb-actions' },
 					el('span', { class: 'file-thumb-document-size' },
 						map(file._diskSize, function (size) {

--- a/view/domjs-ext/thumb-old.js
+++ b/view/domjs-ext/thumb-old.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var map     = require('observable-value/map')
-  , resolve = require('observable-value/resolve');
+var map = require('observable-value/map');
 
 module.exports = function (domjs/*, options*/) {
 	var ns = domjs.ns, a = ns.a, i = ns.i, img = ns.img, p = ns.p, span = ns.span;
 	domjs.ns.thumb = function (file) {
 		return p(a({ href: file._url, target: '_blank', class: 'thumb-doc' },
-			img({ src: stUrl(resolve(file._thumb, '_url')) })),
+			img({ src: file.thumb._url.map(function (thumbUrl) {
+				if (!thumbUrl) return;
+				return stUrl(thumbUrl);
+			}) })),
 			span({ class: 'thumb-doc-action' }, map(file._diskSize, function (size) {
 				if (size == null) return null;
 				return ((size / 1000000).toFixed(2) + ' Mo');

--- a/view/domjs-ext/thumb.js
+++ b/view/domjs-ext/thumb.js
@@ -1,14 +1,16 @@
 'use strict';
 
-var map     = require('observable-value/map')
-  , resolve = require('observable-value/resolve');
+var map = require('observable-value/map');
 
 module.exports = function (domjs/*, options*/) {
 	var ns = domjs.ns, a = ns.a, img = ns.img, span = ns.span, div = ns.div;
 	domjs.ns.thumb = function (file) {
 		return div({ class: 'file-thumb' },
 			a({ href: file._url, target: '_blank', class: 'file-thumb-image' },
-				img({ src: stUrl(resolve(file._thumb, '_url')) })),
+				img({ src: file.thumb._url.map(function (thumbUrl) {
+					if (!thumbUrl) return;
+					return stUrl(thumbUrl);
+				}) })),
 			div({ class: 'file-thumb-actions' }, map(file._diskSize, function (size) {
 				if (size == null) return null;
 				return span({ class: 'file-thumb-document-size' }, (size / 1000000).toFixed(2) + ' Mo');


### PR DESCRIPTION
This should improve the experience in remote locations when CloudFront is configured.

The change is to use `stUrl` wrapper over uploaded images paths.
