### PR TITLE
Do not throw in resolveDefaultStatus

### DIFF
--- a/server/configure-apps-access-rules.js
+++ b/server/configure-apps-access-rules.js
@@ -115,7 +115,6 @@ module.exports = exports = function (dbDriver, data) {
 		var defaultKey = processingStepsDefaultMap[stepShortPath];
 		if (!defaultKey) {
 			console.error("\n\nUnrecognized step short path " + stringify(stepShortPath));
-			return;
 		}
 		return defaultKey;
 	};


### PR DESCRIPTION
We cannot throw here: https://github.com/egovernment/eregistrations/blob/master/server/configure-apps-access-rules.js#L116

because it may happen in regular usage (i.e. in Salvador when we have user on processing and we change his institution to solvency (we get a key which does not exist 'processing/solvency'))
