### PR TITLE
Top menu active is align-left, unactive is align-center

### DIFF
--- a/css/components/submitted-menu.css
+++ b/css/components/submitted-menu.css
@@ -42,7 +42,7 @@
 	text-decoration: none;
 	padding: 0 17px;
 	display: block;
-	text-align: left;
+	text-align: center;
 	line-height: 22px;
 	padding-top: 11px;
 	padding-bottom: 11px;


### PR DESCRIPTION
I dont believe there is a reason to change the alignment with active or non-active.. 

els
<img width="1095" alt="miempresa_gob_sv" src="https://cloud.githubusercontent.com/assets/3383078/14631515/08f7152a-0614-11e6-99aa-2cdd49e1e228.png">

gt
<img width="1083" alt="minegocio_gt" src="https://cloud.githubusercontent.com/assets/3383078/14631525/1a01d404-0614-11e6-87b8-68e4ecfb2e9b.png">

I think they can all be align-center..
