### PR TITLE
Data : label-sm in compact data display

### DIFF
--- a/css/components/entity-data-section.css
+++ b/css/components/entity-data-section.css
@@ -55,3 +55,9 @@
 .entity-data-section-entities li {
 	padding-bottom:22px;
 }
+
+.entity-data-section-entities .entity-data-section-sub .label-reg {
+	font-size: 9px;
+	height: auto;
+	line-height: normal;
+}


### PR DESCRIPTION
We should use a smaller label in the "compact" data. For example for legal representative in GT:

<img width="694" alt="minegocio_gt" src="https://cloud.githubusercontent.com/assets/3383078/14421489/40ef1df8-ffd2-11e5-8fb8-4816a8935fac.png">
