### PR TITLE
Current date service crashes on first start

### DIFF
--- a/server/services/current-date-update.js
+++ b/server/services/current-date-update.js
@@ -28,7 +28,7 @@ module.exports = function (storage, tz) {
 		var currentDate = db.Date((new time.Date()).setTimezone(tz));
 
 		storage.get(key).then(function (data) {
-			if (data.value !== serializeValue(currentDate)) {
+			if (!data || data.value !== serializeValue(currentDate)) {
 				debug('to %s', currentDate.toISOString().slice(0, 10));
 				return storage.store(key, serializeValue(currentDate));
 			}


### PR DESCRIPTION
```
/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/_ext.js:75
            throw this.value;
            ^

TypeError: Cannot read property 'value' of null
    at /Users/medikoo/Projects/eregistrations/tanzania/node_modules/eregistrations/server/services/current-date-update.js:31:12
    at Function.exports._onresolve.then (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/_ext.js:60:18)
    at Object.Deferred._settle (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/deferred.js:84:26)
    at Object.Deferred.resolve (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/deferred.js:127:15)
    at Function.exports._onresolve.then (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/_ext.js:64:4)
    at Object.Deferred._settle (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/deferred.js:84:26)
    at Object.Deferred.resolve (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/deferred.js:127:15)
    at Function.exports._onresolve.then (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/_ext.js:64:4)
    at Object.Deferred._settle (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/deferred.js:84:26)
    at Object.Deferred.reject (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/deferred/deferred.js:135:15)
    at ReadFileContext.resolve [as callback] (/Users/medikoo/Projects/eregistrations/tanzania/node_modules/fs2/read-file.js:23:13)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:303:13)
```
