### PR TITLE
Rev update : have new labels for data validation

### DIFF
--- a/model/business-process-new/data-forms.js
+++ b/model/business-process-new/data-forms.js
@@ -23,8 +23,8 @@ module.exports = memoize(function (db/* options */) {
 
 	// Enum for forms status
 	var DataFormsStatus = StringLine.createEnum('DataFormsStatus', new Map([
-		['approved', { label: _("Valid") }],
-		['rejected', { label: _("Invalid") }]
+		['approved', { label: _("The data is valid") }],
+		['rejected', { label: _("The data is invalid") }]
 	]));
 
 	BusinessProcess.prototype.defineProperties({


### PR DESCRIPTION
I would like to have different labels for the validation and invalidation of the data in the revision screens. 
That means to have new words instead of Valid, Invalid (those words apply more to the documents). 
<img width="762" alt="tiw" src="https://cloud.githubusercontent.com/assets/3383078/15502184/afb7a3b6-21b2-11e6-945b-e3e26059b8fe.png">

I would like to have : 
- "The data is valid"
- "The data is invalid"
