### PR TITLE
Smarter views resolvent handling for sections toDOMFieldset

### DIFF
--- a/view/dbjs/form-section-base-get-resolvent.js
+++ b/view/dbjs/form-section-base-get-resolvent.js
@@ -45,7 +45,7 @@ module.exports = Object.defineProperty(db.FormSectionBase.prototype, 'getFormRes
 					(dbjsInput.observable.descriptor.inputOptions.multiline === false))) {
 					dbjsInput.dom.classList.add('multiline');
 				}
-				result.legacyScript = ns.legacy('radioMatch', this.domId,
+				result.legacyScript = ns.legacy('radioMatch', options.formId || this.domId,
 						master.__id__ + '/' + this.resolventProperty,
 					match);
 			}


### PR DESCRIPTION
It's about cases when we draw a section with only a `toDOMFieldset`. In that case we shouldn't assume that our container's id is simply `this.domId` (as it may be passed from outside like in the guide's case). 
