### PR TITLE
Mardown broken in tooltip

### DIFF
--- a/css/components/input-optional-info.css
+++ b/css/components/input-optional-info.css
@@ -47,6 +47,26 @@
 .input-optional-info-content > * {
 	font-size: 12px;
 	color: #FFF;
+	margin-bottom: 11px;
+}
+
+.input-optional-info-content > *:last-child {
+	margin-bottom: 0;
+}
+
+.input-optional-info-content ul {
+	padding-left: 22px;
+
+}
+
+.input-optional-info-content ul li {
+	list-style-type: disc;
+	margin-bottom: 11px;
+	display: list-item;
+}
+
+.input-optional-info-content ul li:last-child {
+	margin-bottom:0;
 }
 
 .input-optional-info:hover .input-optional-info-content, .input-optional-info:focus .input-optional-info-content {


### PR DESCRIPTION
I have never wondered how markdown would deal with tooltips.. apparently pretty badly..

Can we do something about it? Give it to @melux if it is for him..

Tooltip 
<img width="749" alt="miempresa_gob_sv_and_miempresa_gob_sv" src="https://cloud.githubusercontent.com/assets/3383078/14525909/30a08fd4-0240-11e6-9e89-e0d353bef75d.png">

Markdown
<img width="953" alt="miempresa_gob_sv" src="https://cloud.githubusercontent.com/assets/3383078/14525937/5747e5f6-0240-11e6-88e3-208375d54aa5.png">
