### PR TITLE
Rev update - revision : show the status in the tab 

### DIFF
--- a/css/components/section-tab-nav.css
+++ b/css/components/section-tab-nav.css
@@ -36,6 +36,20 @@
 	display: inline-block;
 }
 
+.section-tab-nav-tab .fa {
+	vertical-align: middle;
+	margin-left: 8px;
+	font-size: 16px;
+}
+
+.section-tab-nav-tab .fa-exclamation {
+	color:var(--error-text);
+}
+
+.section-tab-nav-tab .fa-check {
+	color:var(--success-text);
+}
+
 /* Tabs content section rules (displayed to user) */
 
 .section-tab-nav-tab-content {

--- a/view/business-process-revision.js
+++ b/view/business-process-revision.js
@@ -38,21 +38,35 @@ exports['sub-main'] = {
 				class: 'section-tab-nav-tab',
 				id: 'tab-business-process-documents',
 				href: '/' + this.businessProcess.__id__ + '/'
-			}, _("${ tabNumber } Revision of the documents", { tabNumber: "1." })),
+			}, _("${ tabNumber } Revision of the documents", { tabNumber: "1." }),
+				_if(eq(this.processingStep.requirementUploads._approvalProgress, 1),
+					span({ class: 'fa fa-check' })),
+				_if(gt(this.processingStep.requirementUploads.rejected._size, 0),
+					span({ class: 'fa fa-exclamation' }))),
 
 			_if(resolve(paymentUploads, '_length'),
 				a({
 					class: 'section-tab-nav-tab',
 					id: 'tab-business-process-payments',
 					href: '/' + this.businessProcess.__id__ + '/payment-receipts/'
-				}, _("${ tabNumber } Revision of payments", { tabNumber: "2." }))),
+				}, _("${ tabNumber } Revision of payments", { tabNumber: "2." }),
+					_if(eq(this.processingStep.paymentReceiptUploads._approvalProgress, 1),
+						span({ class: 'fa fa-check' })),
+					_if(gt(this.processingStep.paymentReceiptUploads.rejected._size, 0),
+						span({ class: 'fa fa-exclamation' })))),
 
 			a({
 				class: 'section-tab-nav-tab',
 				id: 'tab-business-process-data',
 				href: '/' + this.businessProcess.__id__ + '/data/'
 			}, _("${ tabNumber } Revision of data",
-				{ tabNumber: _if(resolve(paymentUploads, '_length'), "3.", "2.") })),
+				{ tabNumber: _if(resolve(paymentUploads, '_length'), "3.", "2.") }),
+				_if(and(this.processingStep.dataFormsRevision._isProcessable,
+					eq(this.processingStep.dataFormsRevision._approvalProgress, 1)),
+						span({ class: 'fa fa-check' })),
+				_if(and(this.processingStep.dataFormsRevision._isProcessable,
+					gt(this.processingStep.dataFormsRevision._sentBackProgress, 0)),
+						span({ class: 'fa fa-exclamation' }))),
 
 			_if(exports._processingTabLabel.call(this),
 				function () {


### PR DESCRIPTION
As an improvement (we can do this later if complicated), it might be good to display some visual information on the tabs, about the advancement of the revision. 

What I suggest is : 
- once one document has been declared as unvalid, we show the red exclamation point in the tab, as: 
  <img width="1079" alt="tiw" src="https://cloud.githubusercontent.com/assets/3383078/15502546/e03bd46a-21b4-11e6-9948-9f4425e31067.png">
- once all the documents have been declared as valid, we show a green check in the tab, as:
  <img width="1071" alt="tiw" src="https://cloud.githubusercontent.com/assets/3383078/15502505/a205a284-21b4-11e6-8ad0-1066b9f0a582.png">

Same for payment receipts and data...

I think that this will help the revisor to see what has been revised and what remain to be revised. Do you have other ideas?
