### PR TITLE
Rev update : show specific sections or sub-section in front of each document

### DIFF
--- a/view/business-process-revision-document.js
+++ b/view/business-process-revision-document.js
@@ -56,7 +56,7 @@ exports['selection-preview'] = function () {
 				return renderDocumentRevisionInfo(this);
 			}.bind(this)),
 			mainContent: exports._documentPreviewContent.call(this, documentData),
-			sideContent: renderSections(this.businessProcess.dataForms.dataSnapshot),
+			sideContent: exports._renderSections.call(this),
 			urlPrefix: '/' + this.businessProcess.__id__ + '/',
 			documentsRootHref: '/' + this.businessProcess.__id__ + '/'
 		}),
@@ -65,3 +65,7 @@ exports['selection-preview'] = function () {
 };
 
 exports._documentPreviewContent = Function.prototype;
+
+exports._renderSections = function () {
+	return renderSections(this.businessProcess.dataForms.dataSnapshot);
+};


### PR DESCRIPTION
@Medikoo told me that it is possible to display only specific sections in front of each document, in the revision screen, A8, Doc tab in part B. 

Now, is is possible to show sub-sections ? 

Is it possible to show different sections ? 

Is it possible to show sub-sections of different sections ? 
