### PR TITLE
A8 when file has been sent : success message

### DIFF
--- a/css/components/entities-overview.css
+++ b/css/components/entities-overview.css
@@ -89,7 +89,21 @@
 	background-color: var(--success-background);
 	color: var(--white-text);
 }
-.entities-overview-info-success .fa-close {
-	float: right;
+
+.entities-overview-info-success {
+	display: flex;
+	justify-content: space-between;
+}
+
+.entities-overview-info-message {
+	flex: 1;
+	padding-right: 10px;
+}
+
+.entities-overview-info-dismiss {
+	text-align: right;
+}
+
+.entities-overview-info-dismiss .fa-close {
 	cursor: pointer;
 }

--- a/css/legacy/components/entities-overview.css
+++ b/css/legacy/components/entities-overview.css
@@ -1,0 +1,7 @@
+.entities-overview-info-message {
+	float: left;
+}
+
+.entities-overview-info-dismiss {
+	float: right;
+}

--- a/view/components/business-process-main-info.js
+++ b/view/components/business-process-main-info.js
@@ -36,9 +36,11 @@ module.exports = function (context) {
 			return timeInMs >= Date.now() - (1000 * 60);
 		}), eq(context.user._currentRoleResolved, 'user')),
 			div({ id: 'submission-success-message', class: 'entities-overview-info-success' },
-				_("Your file was submitted successfully."),
-				span({ id: 'close-submission-success-message',
-					class: 'fa fa-close' }))), script(function () {
+				div({ class: 'entities-overview-info-message' },
+					_("Your file was submitted successfully.")),
+				div({ class: 'entities-overview-info-dismiss' },
+					span({ id: 'close-submission-success-message',
+						class: 'fa fa-close' })))), script(function () {
 			var successMsg = $('submission-success-message');
 			if (!successMsg || !successMsg.parentNode) return;
 			$('close-submission-success-message').onclick = function (ev) {


### PR DESCRIPTION
We should add a success message on top of A8 just after file has been sent. 

<img width="1091" alt="minegocio_gt" src="https://cloud.githubusercontent.com/assets/3383078/16369164/6ed6433c-3c3f-11e6-9157-c8b99f6769b6.png">

The text is translatable

The success message would disappear after 10 seconds. Bonus : being able to close the message. 

bootstrap success is a good example
