### PR TITLE
Improve document thumb controls actions

### DIFF
--- a/view/dbjs/submission-file.js
+++ b/view/dbjs/submission-file.js
@@ -66,7 +66,7 @@ module.exports = Object.defineProperties(db.File, {
 					el('label', { class: 'file-thumb-action' },
 						el('input', { type: 'checkbox', name: name, value: '' }),
 						el('span', { class: 'fa fa-trash-o' }, "delete")),
-					el('a', { href: file._url, target: '_blank', class: 'file-thumb-action' },
+					el('a', { href: file._url, download: file._name, class: 'file-thumb-action' },
 						el('span', { class: 'fa fa-download' }, "download")))));
 			data.dom.appendChild(itemDom.toDOM ? itemDom.toDOM(this.document) : itemDom);
 			return data;


### PR DESCRIPTION
Currently both clicking on thumb and on download button opens image in new window.
While Download button should invoke real download (`download` attribute)
