### PR TITLE
Provide statusLog history for certificates

### DIFF
--- a/server/services/certificates-status-log.js
+++ b/server/services/certificates-status-log.js
@@ -33,7 +33,7 @@ setupCertLogTrigger = function (config) {
 			if (official && official.value) {
 				statusLogProperties.official = official.value;
 			}
-		} else if (conf.getOfficial && (typeof conf.getOfficial === 'function')) {
+		} else if (typeof conf.getOfficial === 'function') {
 			official = conf.getOfficial(certificate);
 			if (official) {
 				statusLogProperties.official = official;


### PR DESCRIPTION
Implementation notes:
I think we should configure them slightly different than `uploads` status logs (which probably should also be reconfigured)
Instead of listening on `db.objects`, We should listen directly on business process collections (service should be initialized by passing `BusinessProcessX` class) and gather following logs:
- On submission (`isSubmitted === true`) `Submission: Certificate request received`
- For each certificate status change (`certificates/map/*/status`):
  - on pending: `Pending: Certificate is ready for processing`
  - on approved: `Approved: Certificate was issued`
  - on rejected: `Rejected: Certificate request was rejected`
  - on pickup: `Withdraw: Certificate was withdrawn`
