### PR TITLE
Unify isPreviousProcessingStepsSatisfied and isPreviousProcessingStepsSatisfiedDeep

### DIFF
--- a/model/processing-step-base.js
+++ b/model/processing-step-base.js
@@ -74,22 +74,14 @@ module.exports = memoize(function (db) {
 			return this.isApproved || this.isRejected || false;
 		} },
 
-		// Whether all directly previous steps are satisfied (not applicable or successfully passed)
-		isPreviousStepsSatisfied: { type: db.Boolean, value: function (_observe) {
-			if (!this.previousSteps.size) return _observe(this.master._isSubmitted);
-			return this.previousSteps.every(function (step) {
-				return _observe(step._isSatisfied);
-			});
-		} },
-
 		// Whether all previous steps are satisfied (not applicable or successfully passed)
 		// It checks alls steps deep down in chain
 		// This resolution is used purely to detect valid returns
 		// (either from 'sentBack' or 'redelegated' states)
-		isPreviousStepsSatisfiedDeep: { type: db.Boolean, value: function (_observe) {
+		isPreviousStepsSatisfied: { type: db.Boolean, value: function (_observe) {
 			if (!this.previousSteps.size) return !_observe(this.master._isAtDraft);
 			return this.previousSteps.every(function (step) {
-				return _observe(step._isSatisfied) && _observe(step._isPreviousStepsSatisfiedDeep);
+				return _observe(step._isSatisfied) && _observe(step._isPreviousStepsSatisfied);
 			});
 		} },
 

--- a/server/services/business-process-flow.js
+++ b/server/services/business-process-flow.js
@@ -175,9 +175,9 @@ module.exports = function (BusinessProcessType, stepShortPaths/*, options*/) {
 		var returnStatuses = new Set(['sentBack', 'redelegated']);
 		setupTriggers({
 			preTrigger: businessProcessesSubmitted
-				.filterByKeyPath(stepPath + '/isPreviousStepsSatisfiedDeep', false),
+				.filterByKeyPath(stepPath + '/isPreviousStepsSatisfied', false),
 			trigger: businessProcessesSubmitted
-				.filterByKeyPath(stepPath + '/isPreviousStepsSatisfiedDeep', true)
+				.filterByKeyPath(stepPath + '/isPreviousStepsSatisfied', true)
 		}, function (businessProcess) {
 			var step = businessProcess.getBySKeyPath(stepPath)
 			  , returnHandlerResult;

--- a/test/model/processing-step-base.js
+++ b/test/model/processing-step-base.js
@@ -27,11 +27,8 @@ module.exports = function (t, a) {
 	businessProcess.set('isAtDraft', false);
 	businessProcess.set('isSubmitted', true);
 	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, true);
 	a(barStep.isPreviousStepsSatisfied, false);
-	a(barStep.isPreviousStepsSatisfiedDeep, false);
 	a(miszkaStep.isPreviousStepsSatisfied, false);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, false);
 
 	a(fooStep.isApplicable, true);
 	a(fooStep.isClosed, false);
@@ -39,11 +36,8 @@ module.exports = function (t, a) {
 
 	fooStep.isRejected = true;
 	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, true);
 	a(barStep.isPreviousStepsSatisfied, false);
-	a(barStep.isPreviousStepsSatisfiedDeep, false);
 	a(miszkaStep.isPreviousStepsSatisfied, false);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, false);
 	a(fooStep.isClosed, true);
 
 	fooStep.isRejected = false;
@@ -51,11 +45,8 @@ module.exports = function (t, a) {
 
 	fooStep.isApproved = true;
 	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, true);
 	a(barStep.isPreviousStepsSatisfied, false);
-	a(barStep.isPreviousStepsSatisfiedDeep, false);
 	a(miszkaStep.isPreviousStepsSatisfied, false);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, false);
 	a(fooStep.isSatisfiedReady, true);
 	a(fooStep.isClosed, true);
 	fooStep.isApplicable = false;
@@ -63,33 +54,21 @@ module.exports = function (t, a) {
 
 	fooStep.isSatisfied = true;
 	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, true);
 	a(barStep.isPreviousStepsSatisfied, true);
-	a(barStep.isPreviousStepsSatisfiedDeep, true);
 	a(miszkaStep.isPreviousStepsSatisfied, false);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, false);
 
 	barStep.isSatisfied = true;
 	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, true);
 	a(barStep.isPreviousStepsSatisfied, true);
-	a(barStep.isPreviousStepsSatisfiedDeep, true);
 	a(miszkaStep.isPreviousStepsSatisfied, true);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, true);
 
 	businessProcess.set('isAtDraft', true);
-	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, false);
-	a(barStep.isPreviousStepsSatisfied, true);
-	a(barStep.isPreviousStepsSatisfiedDeep, false);
-	a(miszkaStep.isPreviousStepsSatisfied, true);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, false);
+	a(fooStep.isPreviousStepsSatisfied, false);
+	a(barStep.isPreviousStepsSatisfied, false);
+	a(miszkaStep.isPreviousStepsSatisfied, false);
 
 	businessProcess.set('isAtDraft', false);
 	a(fooStep.isPreviousStepsSatisfied, true);
-	a(fooStep.isPreviousStepsSatisfiedDeep, true);
 	a(barStep.isPreviousStepsSatisfied, true);
-	a(barStep.isPreviousStepsSatisfiedDeep, true);
 	a(miszkaStep.isPreviousStepsSatisfied, true);
-	a(miszkaStep.isPreviousStepsSatisfiedDeep, true);
 };


### PR DESCRIPTION
It appears that when we shadow `isReady` (after first processing of given step), we can totally rely on logic of `isPreviousProcessingStepsSatisfiedDeep`

Proposal is:
- Remove `isPreviousProcessingStepsSatisfied`
- Rename `isPreviousProcessingStepsSatisfiedDeep` to `isPreviousProcessingStepsSatisfied` (same with all references to `isPreviousProcessingStepsSatisfiedDeep`)
