### PR TITLE
Don't use Mo to display file size.

### DIFF
--- a/view/components/render-sections-json.js
+++ b/view/components/render-sections-json.js
@@ -122,7 +122,7 @@ exports.customRenderers = {
 			a({ href: pathToUrl(data.path), target: '_blank', class: 'file-thumb-image' },
 				img({ src: thumbUrl ? stUrl(thumbUrl) : thumbUrl })),
 			div({ class: 'file-thumb-actions' },
-				span({ class: 'file-thumb-document-size' }, (data.diskSize / 1000000).toFixed(2) + ' Mo'),
+				span({ class: 'file-thumb-document-size' }, (data.diskSize / 1000000).toFixed(2) + ' MB'),
 				a({ href: pathToUrl(data.path), target: '_blank', class: 'file-thumb-action',
 					download: data.path }, span({ class: 'fa fa-download' }, "download"))));
 	},

--- a/view/components/uploaded-file.js
+++ b/view/components/uploaded-file.js
@@ -5,7 +5,7 @@ var ns = require('mano').domjs.ns
 
 var resolveSize = function (size) {
 	if (size == null) return null;
-	return ((size / 1000000).toFixed(2) + ' Mo');
+	return ((size / 1000000).toFixed(2) + ' MB');
 };
 
 module.exports = function (observable/*, options*/) {

--- a/view/components/uploaded-files-list.js
+++ b/view/components/uploaded-files-list.js
@@ -5,7 +5,7 @@ var ns = require('mano').domjs.ns
 
 var resolveSize = function (size) {
 	if (size == null) return null;
-	return ((size / 1000000).toFixed(2) + ' Mo');
+	return ((size / 1000000).toFixed(2) + ' MB');
 };
 
 module.exports = function (files/*, options*/) {

--- a/view/dbjs/submission-file.js
+++ b/view/dbjs/submission-file.js
@@ -61,7 +61,7 @@ module.exports = Object.defineProperties(db.File, {
 					el('span', { class: 'file-thumb-document-size' },
 						map(file._diskSize, function (size) {
 							if (size == null) return null;
-							return ((size / 1000000).toFixed(2) + ' Mo');
+							return ((size / 1000000).toFixed(2) + ' MB');
 						})),
 					el('label', { class: 'file-thumb-action' },
 						el('input', { type: 'checkbox', name: name, value: '' }),

--- a/view/domjs-ext/thumb.js
+++ b/view/domjs-ext/thumb.js
@@ -18,7 +18,7 @@ module.exports = function (domjs/*, options*/) {
 				}) })),
 			div({ class: 'file-thumb-actions' }, map(file._diskSize, function (size) {
 				if (size == null) return null;
-				return span({ class: 'file-thumb-document-size' }, (size / 1000000).toFixed(2) + ' Mo');
+				return span({ class: 'file-thumb-document-size' }, (size / 1000000).toFixed(2) + ' MB');
 			}),
 				a({ href: file._url, target: '_blank', class: 'file-thumb-action' },
 					span({ class: 'fa fa-download' }, "download"))));


### PR DESCRIPTION
@kamsi @medikoo 
First reason: `Mo` means Mega Octet (meaning million of 8 bits) and system reports in bytes (which is not 8 bits only on some archaic architectures, but still...).
Second reason: `octet` is not commonly used these days, causing confusion.

I propose to use either:
- `MB` - Megabyte, in context of file size, meaning 2<sup>20</sup> B - 1 048 576 bytes
- `MiB` - Mebibyte, unambiguous in any context, also meaning 2<sup>20</sup> B - 1 048 576 bytes
