### PR TITLE
Make env.js optional

### DIFF
--- a/server/env.js
+++ b/server/env.js
@@ -23,7 +23,7 @@ if (!env.url) {
 	env.url = 'http://localhost:' + env.port + '/';
 }
 
-// smtp: objects
+// smtp: object
 // Defaults to logOnly configuration
 if (!env.smtp) {
 	env.smtp = {


### PR DESCRIPTION
We need util that's used for automatic resolution of env defaults, so no work on developer part is required.

It'll work as follows:
- We will include `server/env` module in each system repository, and refer to it instead of `env`.
- `server/env` will try to require `env` from main folder, and ignore eventual error, then it will require `eregistrations/server/env` which will setup eventual missing defaults
