### PR TITLE
Ensure DOM bindings for observables are required for each app generator.

### DIFF
--- a/scripts/generate-app/templates/client/program.js/public.tpl
+++ b/scripts/generate-app/templates/client/program.js/public.tpl
@@ -19,6 +19,10 @@ require('mano/lib/client/implement-es');
 // TODO: Require here strictly to log (there should be no log in imported module)
 require('mano/lib/client/client-id');
 
+// DOM bindings for observables
+// TODO: Should not be here
+require('mano/lib/observable-dom');
+
 // Env settings
 require('../../../apps-common/client/env');
 


### PR DESCRIPTION
This require should be in all `client/program.js` files (even public):

``` javascript
require('mano/lib/observable-dom');
```
