### PR TITLE
404 page should be presented together with top user menu

### DIFF
--- a/view/404.js
+++ b/view/404.js
@@ -2,9 +2,9 @@
 
 var _ = require('mano').i18n.bind('View');
 
-exports._parent = require('./base');
+exports._parent = require('./user-base');
 
-exports.main = function () {
+exports['sub-main'] = function () {
 	div(
 		{ class: 'error-page content user-forms' },
 		div(


### PR DESCRIPTION
It should be ensured in all systems, currenlty in ELS it's not the case

Not 404:

![screen shot 2016-09-08 at 11 08 09](https://cloud.githubusercontent.com/assets/122434/18343649/92a4d6da-75b4-11e6-886c-841c81d1bdc1.png)

404:

![screen shot 2016-09-08 at 11 08 51](https://cloud.githubusercontent.com/assets/122434/18343690/aed7e5ea-75b4-11e6-8eee-f778baf772cd.png)

Best if it also comes with submitted menu (roles menu). I think bug comes from history, where we used same 404 page also for public page, now it's not the case. It's ok to assume that 404 is for all user apps.
