### PR TITLE
Improve admin dropdown menu

### DIFF
--- a/view/user-base.js
+++ b/view/user-base.js
@@ -231,8 +231,11 @@ exports._userNameMenuItem = function () {
 };
 
 exports._getRoleMenuItem = function (role) {
-	var user      = this.manager || this.user
-	  , roleTitle = db.Role.meta[role].label;
+	var user = this.manager || this.user
+	  , roleTitle;
+
+	if (!db.Role.meta[role]) return;
+	roleTitle = db.Role.meta[role].label;
 
 	if (user.currentRoleResolved === role) {
 		return li({ class: 'header-top-menu-dropdown-item-active' }, a({ href: '/' }, roleTitle));


### PR DESCRIPTION
Following #1532 , we would like to have the admin pages accessible only from the top dropdown menu (and not anymore by the barre menu). 

This applies to the following pages (please respect also this order): 

The order of the pages in this menu will be :
- Statistics
- Access to all files
- Operations Log (when we will have one)

_separation_
- Translation
- User management

_separation_
- Accounting (when done)

_separation_
- My profile
- Log out
