### PR TITLE
Top-dropdown-menu : fix active page

### DIFF
--- a/css/components/header-top.css
+++ b/css/components/header-top.css
@@ -173,7 +173,6 @@ Flexible basic menu button positioning
 	border-radius: 0 0 3px 3px;
 	border: 1px solid var(--light-inner-border);
 	border-top: none;
-	padding:11px 0;
 	z-index: 1010;
 	position: absolute;
 	top: 100%;
@@ -192,7 +191,7 @@ Flexible basic menu button positioning
 	width: 100%;
 	text-align: left;
 	border-radius: 0;
-	padding: 4px 8px;
+	padding: 11px 8px;
 }
 
 .header-top-dropdown button {


### PR DESCRIPTION
<img width="1086" alt="miempresa_gob_sv" src="https://cloud.githubusercontent.com/assets/3383078/18543468/4e78eda8-7b30-11e6-8aea-8313d6c7cc48.png">

The dropdown menu has a strange design behaviour : 
- the active page does not look like active, 
- a weird orange background is set on different links in the dropdown (it seems random).

Please set only the active page with a coloured background.  

@medikoo please give it to @melux only when the only remaining thing would be to do the design of the active page in the selector, thanks.
