### PR TITLE
Users management : differenciate roles and pages

### DIFF
--- a/view/dbjs/roles-to-dom-input.js
+++ b/view/dbjs/roles-to-dom-input.js
@@ -28,6 +28,28 @@ RolesInput.prototype = Object.create(RoleEnumMultiple.prototype, assign({
 				this.secondSubList = ul()
 			),
 			this.markEmpty);
+	}),
+	customRenderItem: d(function (input, label, value) {
+		var el = this.make, isDisabled, rolesMetaEntry;
+		rolesMetaEntry = this.observable.object.rolesMeta[value];
+		isDisabled = rolesMetaEntry ? rolesMetaEntry._canBeDestroyed.map(function (canBeDestroyed) {
+			return !canBeDestroyed;
+		}) : false;
+
+		if (isDisabled) {
+			var onIsDisabledChanged = function () {
+				if (isDisabled.value) {
+					input.dom.setAttribute('onclick',
+						'event.preventDefault ? event.preventDefault() : (event.returnValue = false)');
+				} else {
+					input.dom.removeAttribute('onclick');
+				}
+			};
+			isDisabled.on('change', onIsDisabledChanged);
+			onIsDisabledChanged();
+		}
+
+		return el('li', { class: [_if(isDisabled, "disabled")] }, el('label', input, " ", label));
 	})
 }, autoBind({
 	reload: d(function () {
@@ -60,32 +82,4 @@ RolesInput.prototype = Object.create(RoleEnumMultiple.prototype, assign({
 	})
 })));
 
-roleEnum = roleEnum(db.Role);
-roleEnum.DOMMultipleInput = RolesInput;
-
-Object.defineProperties(db.User.prototype.getOwnDescriptor('roles'), {
-	inputOptions: d({
-		renderItem: function (input, label, value) {
-			var el = this.make, isDisabled, rolesMetaEntry;
-			rolesMetaEntry = this.observable.object.rolesMeta[value];
-			isDisabled = rolesMetaEntry ? rolesMetaEntry._canBeDestroyed.map(function (canBeDestroyed) {
-				return !canBeDestroyed;
-			}) : false;
-
-			if (isDisabled) {
-				var onIsDisabledChanged = function () {
-					if (isDisabled.value) {
-						input.dom.setAttribute('onclick',
-							'event.preventDefault ? event.preventDefault() : (event.returnValue = false)');
-					} else {
-						input.dom.removeAttribute('onclick');
-					}
-				};
-				isDisabled.on('change', onIsDisabledChanged);
-				onIsDisabledChanged();
-			}
-
-			return el('li', { class: [_if(isDisabled, "disabled")] }, el('label', input, " ", label));
-		}
-	})
-});
+db.User.prototype.getOwnDescriptor('roles').DOMInput = RolesInput;


### PR DESCRIPTION
We need to set in the users management page the difference that exists between : 
- the roles : the processing of the applications by each institutions
- the pages : everything that is not Part A nor Part B. 

For this, we should put the "meta admin", "users management", etc. under a "Page(s)" field, as follows : 

![pages](https://cloud.githubusercontent.com/assets/3383078/18545537/da85310e-7b39-11e6-83dd-973c8b3e9494.png)
