### PR TITLE
Fix password leak

### DIFF
--- a/server/data-fragments/get-direct-object-fragments.js
+++ b/server/data-fragments/get-direct-object-fragments.js
@@ -62,5 +62,9 @@ module.exports = memoize(function (storage) {
 			});
 		});
 		return fragment;
-	}, { primitive: true });
+	}, { normalizer: function (args) {
+		var options = args[1];
+		if (!options || !options.filter) return args[0];
+		return args[0] + '|' + String(options.filter);
+	} });
 }, { primitive: true });


### PR DESCRIPTION
In low level fragment generator, there was unwise assumption that for given storage setting retrieved objects will be always using same eventual filter.

After optimizations done in #1444 user fragments were changed to use _no storage_ variant, and then it turned it was used  twice as [unfiltered](https://github.com/egovernment/eregistrations-guatemala/blob/master/server/services/db/index.js#L21) and [filtered](https://github.com/egovernment/eregistrations/blob/master/server/configure-apps-access-rules.js#L212-L213) variant, that exposed password hash leak to clients in some scenarios.
