### PR TITLE
Missing hash-nav-document-link require in user apps legacy template

### DIFF
--- a/scripts/generate-app/templates/client/legacy/index.js/user.tpl
+++ b/scripts/generate-app/templates/client/legacy/index.js/user.tpl
@@ -15,3 +15,4 @@ require('mano-legacy/hash-nav-modal');
 require('mano-legacy/confirm-submit');
 require('mano-legacy/hash-nav-ordered-list-controls');
 require('eregistrations/client/legacy/form-section-state-helper');
+require('eregistrations/client/legacy/hash-nav-document-link');


### PR DESCRIPTION
As in https://github.com/egovernment/eregistrations-guatemala/pull/887
