### PR TITLE
Smarter inserts with step numbers

### DIFF
--- a/view/business-process-submission-forms.js
+++ b/view/business-process-submission-forms.js
@@ -84,7 +84,7 @@ exports._disableCondition = function () {
 };
 
 var getHeadingText = function (isPaymentEnabled) {
-	return _("${ stepNumber } Send your files", { stepNumber: isPaymentEnabled ? 4 : 3 }).join("");
+	return String(_("${ stepNumber } Send your files", { stepNumber: isPaymentEnabled ? 4 : 3 }));
 };
 
 exports._submissionHeading = function () {


### PR DESCRIPTION
Right now the form steps inserts have hardcoded numbers (1-4). So, whenever one of the steps is removed (like when we don't have to pay the payments step is removed) the nest steps header is left with invalid number.

This can be easily observed in demo project https://github.com/egovernment/eregistrations-demo .

![image](https://cloud.githubusercontent.com/assets/7392217/19600962/8cbb4168-97a7-11e6-8d83-88d83cc71f1c.png)

Despite the fact that we now less steps, the number is still 4 instead of 3.

![image](https://cloud.githubusercontent.com/assets/7392217/19600947/7ed0820c-97a7-11e6-8d8b-21cf81b60cf2.png)
