### PR TITLE
In businessProcess apps wait for businessProcess data

### DIFF
--- a/scripts/generate-app/templates/client/program.js/business-process.tpl
+++ b/scripts/generate-app/templates/client/program.js/business-process.tpl
@@ -95,7 +95,7 @@ loadView = function () {
 		return;
 	}
 	user = db.User.getById(userId);
-	if (!user) {
+	if (!user || !user.currentBusinessProcess) {
 		server.once('sync', loadView);
 		console.log(".. Waiting for user data ..");
 		return;


### PR DESCRIPTION
On slow connections when moving from user to businessProcess app, may trigger premature view load, when no business process data is loaded, and view render breaks with an error.

This error can only be recovered with reload of page, so it's bad for user.
Introduced here fix, postpones render of views in businessProcess apps until we have businessProcess in question.

Error picked through client error reporting. 

It follows with PR's to all systems using latest program.js format (so all apart of Lomas)

```
Client & Session Id:

613p9hlp2ktx:7161v7r8o91u

User Agent:

Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36

Referer:

https://miempresa.gob.sv/

IP:

::ffff:127.0.0.1

Location: 

"https://miempresa.gob.sv/"

Message: 

"Uncaught TypeError: Cannot read property '_guideProgress' of null"

Source: 

"https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js"

Line: 

1

Column: 

3181944

Error Message: 

"Cannot read property '_guideProgress' of null"

Error Stack: 

"TypeError: Cannot read property '_guideProgress' of null\n    at Object.a._stepsMenu (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3181944)\n    at Object.a._stepsMenuContainer (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3183664)\n    at Object.a.sub-main (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3181834)\n    at b.<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:328296)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:350848)\n    at c (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3127301)\n    at https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2835790\n    at Array.forEach (native)\n    at https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2835733\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3126694)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3131945)\n    at b (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:34195)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3131825)\n    at https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3127705\n    at Array.forEach (native)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3127683)\n    at Object.a.(anonymous function) (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3134442)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:29606)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3134587)\n    at .<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:29258)\n    at d.t (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2679224)\n    at d.m (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2902173)\n    at d.<anonymous> (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2920860)\n    at b (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2679311)\n    at Object.program.js (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:2679767)\n    at e (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:1060)\n    at h (https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:1400)\n    at https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:1460\n    at https://d2n7qp1it8qrl2.cloudfront.net/business-process-merchant.js:1:3238468"
```
