### PR TITLE
Fix handling of server update triggered uploads submissions

### DIFF
--- a/controller/registration/index.js
+++ b/controller/registration/index.js
@@ -63,7 +63,7 @@ exports['requirement-upload/[a-z][a-z0-9-]*'] = {
 	},
 	submit: function (data) {
 		// As form is set with "auto submit", the submission may be triggered not only
-		// by user update, by also by data update coming from the server.
+		// by user update but also by data update coming from the server.
 		// In the later case we don't want to introduce side effects (reset revision status etc.)
 		if (isEmpty(data)) return;
 		if (this.requirementUpload.status) this.requirementUpload.delete('status');
@@ -88,7 +88,7 @@ exports['payment-receipt-upload/[a-z][a-z0-9-]*'] = {
 	},
 	submit: function (data) {
 		// As form is set with "auto submit", the submission may be triggered not only
-		// by user update, by also by data update coming from the server.
+		// by user update but also by data update coming from the server.
 		// In the later case we don't want to introduce side effects (reset revision status etc.)
 		if (isEmpty(data)) return;
 		if (this.paymentReceiptUpload.status) this.paymentReceiptUpload.delete('status');


### PR DESCRIPTION
Uploads form have "auto submit" feature, which means that form submissions are triggered on any inputs change. This happens also when inputs are filled by data from server (not only through direct user interactions).
Current logic of controllers unconditionally introduced side effects on files (e.g. reset status of files) in case of submissions.

It caused some files in GT got back with not expected state (reported here ->https://github.com/egovernment/eregistrations-guatemala/issues/895 )
User got into documents page before all data from server arrived. When data arrived it triggered controllers and reset statuses for uploaded docs. Then after sending file back, file landed at first revision role, as it's uploads had statuses deleted.
