### PR TITLE
Ensure correct legacy settings for statistics

### DIFF
--- a/scripts/generate-app/templates/client/legacy/index.js/statistics.tpl
+++ b/scripts/generate-app/templates/client/legacy/index.js/statistics.tpl
@@ -1,0 +1,14 @@
+// Legacy function implementations
+
+'use strict';
+
+require('mano-legacy/html5');
+require('mano-legacy/ie8-font-visibility-fix');
+
+window.$ = require('mano-legacy');
+
+require('mano-legacy/live/input-mask');
+//Logs client errors to server logs
+require('eregistrations/client/legacy/error-logger');
+
+require('mano-legacy/element#/toggle');


### PR DESCRIPTION
In legacy mode statistics charts crashed as `toggle` methods are not ensured on elements.

It worked in SPA by chance, as then domjs ensures `toggle` methods on all elements that are created through it.