### PR TITLE
Fix resolution of applicable documents list

### DIFF
--- a/view/components/business-process-certificates-list.js
+++ b/view/components/business-process-certificates-list.js
@@ -13,7 +13,7 @@ var normalizeOptions      = require('es5-ext/object/normalize-options')
 module.exports = function (context/*, options*/) {
 	var options            = normalizeOptions(arguments[1])
 	  , businessProcess    = context.businessProcess
-	  , target             = options.uploadsResolver || businessProcess
+	  , target             = context.processingStep || businessProcess
 	  , certificates       = getCertificates(target.certificates, context.appName)
 	  , resolveDocumentUrl = getResolveDocumentUrl('certificate', certificates, options);
 

--- a/view/components/business-process-documents-list.js
+++ b/view/components/business-process-documents-list.js
@@ -11,7 +11,7 @@ var normalizeOptions      = require('es5-ext/object/normalize-options')
 module.exports = function (context/*, options*/) {
 	var options            = normalizeOptions(arguments[1])
 	  , businessProcess    = context.businessProcess
-	  , target             = options.uploadsResolver || businessProcess
+	  , target             = context.processingStep || businessProcess
 	  , uploads            = getUploads(target.requirementUploads, context.appName)
 	  , resolveDocumentUrl = getResolveDocumentUrl('requirementUpload', uploads, options);
 

--- a/view/components/business-process-payments-list.js
+++ b/view/components/business-process-payments-list.js
@@ -11,7 +11,7 @@ var normalizeOptions      = require('es5-ext/object/normalize-options')
 module.exports = exports = function (context/*, options*/) {
 	var options            = normalizeOptions(arguments[1])
 	  , businessProcess    = context.businessProcess
-	  , target             = options.uploadsResolver || businessProcess
+	  , target             = context.processingStep || businessProcess
 	  , uploads            = getUploads(target.paymentReceiptUploads, context.appName)
 	  , resolveDocumentUrl = getResolveDocumentUrl('paymentReceiptUpload', uploads, options);
 

--- a/view/components/document-preview.js
+++ b/view/components/document-preview.js
@@ -39,7 +39,7 @@ module.exports = exports = function (context, documentData/*, options*/) {
 	var options          = normalizeOptions(arguments[2])
 	  , mainContent      = options.mainContent
 	  , businessProcess  = context.businessProcess
-	  , collectionTarget = options.uploadsResolver || businessProcess
+	  , collectionTarget = context.processingStep || businessProcess
 	  , kind             = context.documentKind
 
 	  , collection, nextDocumentUrl, previousDocumentUrl, docPreviewElement, sideContentContainer


### PR DESCRIPTION
/cc @kamsi 

It appears accessible documents list filter (per step) was not working as expected.

It worked only in case of all documents being filtered (the only case we have now in GT), where we hidden whole tab.

Tested in all apps, works as expected.