### PR TITLE
Improve service box configuration handling

### DIFF
--- a/view/user.js
+++ b/view/user.js
@@ -61,7 +61,7 @@ exports['sub-main'] = {
 						  , renderAsDiv = not(renderAsForm)
 						  , boxClasses = [ 'user-account-service-box', _if(disabled, 'disabled') ];
 
-						// Explanation superfluous _if usage within configuration below
+						// Explanation of superfluous _if usage within configuration below:
 						// As item.content and item.buttonContent can be used in two scenarios (form and aHref)
 						// which may toggle during time of interface being displayed, we need to ensure that
 						// very same DOM content is moved between two containers, and that can only be ensured


### PR DESCRIPTION
- Ensured that `renderAsDiv` is negation of `renderAsForm` and there can't be situation where both are falsy (it allows to create `<a>` elements with no href)
- Document internal superfluous `_if` usage.

@mtuchowski this is needed, so you can pass `null` as href in #1602