### PR TITLE
Workaround observability limitations

### DIFF
--- a/view/components/incomplete-form-nav-rules.js
+++ b/view/components/incomplete-form-nav-rules.js
@@ -103,16 +103,16 @@ generateMissingList = function (formSection, level) {
 };
 
 module.exports = function (sections) {
-	return ul(sections, function (formSection) {
-
-		return _if(formSection._hasDisplayableRuleDeep,
-			section(
-				a(
-					{ href: '#' + formSection.domId },
-					formSection.onIncompleteMessage || _("${sectionLabel} is invalid",
-						{ sectionLabel: formSection.label })
-				),
-				generateMissingList(formSection)
-			));
+	var incompleteSections = sections.filter(function (section) {
+		section._hasDisplayableRuleDeep.once('change', function () {
+			incompleteSections.refresh(section);
+		});
+		return section.hasDisplayableRuleDeep;
+	});
+	return ul(incompleteSections, function (formSection) {
+		return section(a({ href: '#' + formSection.domId },
+			formSection.onIncompleteMessage || _("${sectionLabel} is invalid",
+				{ sectionLabel: formSection.label })),
+			generateMissingList(formSection));
 	});
 };


### PR DESCRIPTION
Reported here: https://github.com/egovernment/eregistrations-guatemala/pull/935#pullrequestreview-10078213

Proposed fix workarounds limitations of using `_if` results as returns to observable list generator.

Tested, issue doesn't appear with that.