### PR TITLE
Fix date for costs print

### DIFF
--- a/server/routes/controllers/business-process-costs-print.js
+++ b/server/routes/controllers/business-process-costs-print.js
@@ -27,7 +27,7 @@ module.exports = function (BusinessProcess/*, options */) {
 
 			// Common inserts.
 			inserts.locale       = db.locale;
-			inserts.currentDate  = toDateTimeInTz(new Date(), db.timeZone).toString();
+			inserts.currentDate  = new db.DateTime(toDateTimeInTz(new Date(), db.timeZone)).toString();
 			inserts.logo         = options.logo;
 			inserts.businessName = data.businessName || '';
 			inserts.total        = data.total || '0';


### PR DESCRIPTION
As reported here: https://github.com/egovernment/eregistrations-guatemala/issues/957

The costs date should be relative to given service's timeZone, currently it's not.