### PR TITLE
Introduce localStorage validation for SPA mode

### DIFF
--- a/prototype/view/base.js
+++ b/prototype/view/base.js
@@ -12,10 +12,16 @@ exports.head = function () {
 	if (isReadOnlyRender) {
 		// SPA takeover
 		script(function (appUrl) {
-			var isStrict;
+			var isStrict, hasLocalStorage;
 			if (typeof Object.getPrototypeOf !== 'function') return;
 			if (typeof Object.defineProperty !== 'function') return;
 			if (!window.history) return;
+			if (!window.localStorage) return;
+			try {
+				localStorage.$test = '';
+				hasLocalStorage = true;
+			} catch (ignore) {}
+			if (!hasLocalStorage) return;
 			isStrict = !(function () { return this; }());
 			if (!isStrict) return;
 			if (Object.getPrototypeOf({ __proto__: Function.prototype }) !== Function.prototype) return;

--- a/prototype/view/index.html
+++ b/prototype/view/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <!-- Loaded only in server-side render mode or in dev mode -->
 	<script data-spa>
-if (!Object.getPrototypeOf || !Object.defineProperty || !window.history ||
+if (!Object.getPrototypeOf || !Object.defineProperty || !window.history || !window.localStorage ||
+		!(function () { try { localStorage.$test = ''; return true; } catch (ignore) {} }()) ||
 		(function () {'use strict'; return this; }()) ||
 	 (Object.getPrototypeOf({ __proto__: Function.prototype }) !==
 		 Function.prototype) || (Object.defineProperty({}, 'foo',

--- a/scripts/generate-app/extra-files/apps/public/view/inserts.js
+++ b/scripts/generate-app/extra-files/apps/public/view/inserts.js
@@ -17,10 +17,16 @@ exports.stRoot = stUrl('');
 // SPA take over handler
 if (isReadOnlyRender) {
 	exports.spaTakeOver = script(function (appUrl) {
-		var isStrict;
+		var isStrict, hasLocalStorage;
 		if (typeof Object.getPrototypeOf !== 'function') return;
 		if (typeof Object.defineProperty !== 'function') return;
 		if (!window.history) return;
+		if (!window.localStorage) return;
+		try {
+			localStorage.$test = '';
+			hasLocalStorage = true;
+		} catch (ignore) {}
+		if (!hasLocalStorage) return;
 		isStrict = !(function () { return this; }());
 		if (!isStrict) return;
 		if (Object.getPrototypeOf({ __proto__: Function.prototype }) !== Function.prototype) return;

--- a/scripts/generate-app/templates/index.html.tpl/meta-admin.tpl
+++ b/scripts/generate-app/templates/index.html.tpl/meta-admin.tpl
@@ -3,7 +3,8 @@
 	<meta name="viewport" content="width=device-width" />
 	<noscript><meta http-equiv="refresh" content="0;/?legacy=1" /></noscript>
 	<script data-spa>
-if (!Object.getPrototypeOf || !Object.defineProperty || !window.history ||
+if (!Object.getPrototypeOf || !Object.defineProperty || !window.history || !window.localStorage ||
+		!(function () { try { localStorage.$test = ''; return true; } catch (ignore) {} }()) ||
 		(function () {'use strict'; return this; }()) ||
 	 (Object.getPrototypeOf({ __proto__: Function.prototype }) !==
 		 Function.prototype) || (Object.defineProperty({}, 'foo',

--- a/scripts/generate-app/templates/index.html.tpl/statistics.tpl
+++ b/scripts/generate-app/templates/index.html.tpl/statistics.tpl
@@ -4,7 +4,8 @@
 	<noscript><meta http-equiv="refresh" content="0;/?legacy=1" /></noscript>
 	<script src="https://www.gstatic.com/charts/loader.js"></script>
 	<script data-spa>
-if (!Object.getPrototypeOf || !Object.defineProperty || !window.history ||
+if (!Object.getPrototypeOf || !Object.defineProperty || !window.history || !window.localStorage ||
+		!(function () { try { localStorage.$test = ''; return true; } catch (ignore) {} }()) ||
 		(function () {'use strict'; return this; }()) ||
 	 (Object.getPrototypeOf({ __proto__: Function.prototype }) !==
 		 Function.prototype) || (Object.defineProperty({}, 'foo',


### PR DESCRIPTION
It's to address two cases
- (very rare) client passes all other validation steps, but do not implement `localStorage`
- Safari client runs in incognito mode (then `localStorage` while existing it's not accessible for writes).
