### PR TITLE
Support user language in business process email notifications

### DIFF
--- a/view/business-processes-table.js
+++ b/view/business-processes-table.js
@@ -18,6 +18,7 @@ exports['sub-main'] = {
 	content: function () {
 		var searchForm, searchInput, businessProcessesTable, formAction;
 		formAction = getDynamicUrl('/', { filter: exports._urlParams });
+		exports._optionalContentTop.call(this);
 		renderStatsOverview(this);
 		exports._optionalContent.call(this);
 		// this should not happen, but it might if we don't block illegal role dependencies
@@ -73,5 +74,6 @@ exports['sub-main'] = {
 };
 
 exports._optionalContent = Function.prototype;
+exports._optionalContentTop = Function.prototype;
 exports._statusMap = Function.prototype;
 exports._businessProcessTable = Function.prototype;


### PR DESCRIPTION
Should be addressed after #1617 and #1618

Applies strictly to business process email notifications (as released by `business-process-email-notifications` service)

Firstly, we need to reconfigure how we handle `to`, `cc`, and `bcc`. At this point just having _email_ is not enough. We need to have it together with `lang`.

Having that we resolve messages in specific language as folows:

``` javascript
_.locale = esMessages // if user language is "es", we assign content of i18n-messages.es.json
var translatedText = _("Notification text");
_.locale = defaultMessages // Set back default i18n-messages.{default}.json
```
