### PR TITLE
Superuser improvement 2 : one last detail

### DIFF
--- a/view/users-table.js
+++ b/view/users-table.js
@@ -27,9 +27,14 @@ exports._emailColumn = {
 
 exports._roleColumn = {
 	head: _("Role"),
-	data: function (user) { return ul(user.roles, function (role) {
-		return exports._mapRolesToLabels(role, user);
-	}); }
+	data: function (user) {
+		return user._isSuperUser.map(function (isSuperUser) {
+			if (isSuperUser) return _("Superuser");
+			return ul(user.roles, function (role) {
+				return exports._mapRolesToLabels(role, user);
+			});
+		});
+	}
 };
 
 exports._institutionColumn = {


### PR DESCRIPTION
Following #1696, a last improvement : it would be good to see "Superuser" fonctionnality attribution from the list of users = if an account is set with `superuser` = Yes, see only "Superuser" word in the list of users (and not the full list of roles + pages that come with Superuser).

Example below where we could replace all this with "Superuser"

![capture65](https://cloud.githubusercontent.com/assets/3383078/21005969/3ea14288-bd37-11e6-8ef0-8089b912bb1a.PNG)
 
Note : for all the things that remain from #1696, I will open the issues for the specific systems.