### PR TITLE
All files : have submitted-menu

### DIFF
--- a/view/inspector.js
+++ b/view/inspector.js
@@ -17,7 +17,7 @@ exports._parent = require('./abstract-user-base');
 exports['submitted-menu'] = function () {
 	li(
 		{ id: 'inspector-nav', class: 'submitted-menu-item-active' },
-		a({ href: '/' }, _("All files"))
+		a({ href: '/' }, db.Role.meta.inspector.label)
 	);
 };
 


### PR DESCRIPTION
To keep the uniformity of all the pages of eRegistrations, let's add the `submitted-menu` in the new All files page. 

The title would simply be "All files". 

<img width="1090" alt="miempresa_gob_sv" src="https://cloud.githubusercontent.com/assets/3383078/21137482/f3504a1c-c129-11e6-9583-fe91cccef411.png">
