### PR TITLE
Users Admin: In edit user, email field should be read only

### DIFF
--- a/view/user-edit.js
+++ b/view/user-edit.js
@@ -10,8 +10,8 @@ exports['sub-main'] = {
 	content: function () {
 		var user = this.editedUser, prepend, options = {};
 
-		options.fieldsetOptions = { controls: { email: { disabled: true } },
-			password: { modelRequired: false } };
+		options.fieldsetOptions = { controls: { email: { disabled: true },
+			password: { modelRequired: false } } };
 		prepend = div(
 			{ class: 'entity-header' },
 			h3(_("Edit user: ${ fullName }", { fullName: user._fullName })),


### PR DESCRIPTION
In Users Admin when entering the user it looks that email field is open for edition, which should not be the case.

It's probably regression introduced with recent changes

![screen shot 2016-12-21 at 10 58 21](https://cloud.githubusercontent.com/assets/122434/21385206/f8a252fe-c76d-11e6-9962-9ebbd66ff769.png)

Observed in both ELS and GT, so I assume problem lies here