### PR TITLE
Fix resolution of resolventProperty path for snapshots

### DIFF
--- a/model/form-section.js
+++ b/model/form-section.js
@@ -165,10 +165,16 @@ module.exports = memoize(function (db) {
 			type: StringLine,
 			multiple: true,
 			value: function (_observe) {
-				var result = []
-				  , resolved;
+				var result = [], resolventProperty, resolved;
 
-				if (this.isResolventFilled(_observe)) result.push(this.resolventProperty);
+				if (this.isResolventFilled(_observe)) {
+					resolventProperty = this.resolventProperty;
+					if (this.propertyMaster !== this.master) {
+						resolventProperty = this.propertyMaster.__id__.slice(this.master.__id__.length + 1) +
+							'/' + resolventProperty;
+					}
+					result.push(resolventProperty);
+				}
 
 				if (this.isUnresolved) return result;
 


### PR DESCRIPTION
It appeared that for snapshots when nested entities are involved, the resolvent property was not resolved as expected, therefore producing results as e.g.:

![screen shot 2016-12-22 at 12 37 36](https://cloud.githubusercontent.com/assets/122434/21424484/7301d9a4-c843-11e6-8600-2b2d4597e8a3.png)

Tested, works as expected