### PR TITLE
Notary optimisation : make the "Clients" tab better

### DIFF
--- a/view/manager-home.js
+++ b/view/manager-home.js
@@ -28,7 +28,7 @@ exports['manager-account-content'] = function () {
 				thead(tr(
 					th(_("Client linked to this notary account")),
 					th(_("Services started for this client")),
-					th({ colspan: "2" })
+					_if(manager._isManagerActive, th({ colspan: "2" }))
 				)),
 				tbody(
 					clients,
@@ -53,10 +53,9 @@ exports['manager-account-content'] = function () {
 												action: url('clients', client.__id__, 'delete'),
 												confirm: _("Are you sure?"),
 												value: _("Remove the client's account")
-											}),
-											_("N/A")
+											})
 											)
-									)], td({ colspan: "2" }, _("N/A"))
+									)]
 								)
 						);
 					},


### PR DESCRIPTION
Following #1682, this is point number 2 of the notary optimisation. 

In the "Clients" tab of the notary page, the icons for accessing the clients account and removing the clients account are not very explanatory. I suggest to have 2 columns with : 
- one column is a button "Access the client's account"
- one column is a button "Remove the client's account"

<img width="1073" alt="minegocio_gt" src="https://cloud.githubusercontent.com/assets/3383078/20609678/454b25be-b255-11e6-8369-42dd96752a19.png">

---------------------------

We also must have those two texts changed : 

<img width="730" alt="minegocio_gt" src="https://cloud.githubusercontent.com/assets/3383078/20609866/b448c046-b257-11e6-9565-4fdf1008fae9.png">

We would like to change the left part for "Client linked to this notary account", and the second one "Services" changed to "Services started for this client".