### PR TITLE
SuperUser labelling doesn't work in Users Admin table

### DIFF
--- a/apps/users-admin/user-list-properties.js
+++ b/apps/users-admin/user-list-properties.js
@@ -12,4 +12,4 @@ var Set = require('es6-set');
  */
 
 module.exports = new Set(['firstName', 'lastName', 'email', 'roles', 'institution',
-	'canBeDestroyed']);
+	'canBeDestroyed', 'isSuperUser']);


### PR DESCRIPTION
It looks that egovernment/eregistrations#1699 was not implemented properly.

In ELS I've created user with Super User mark, and it's displayed in table as:

![screen shot 2016-12-27 at 13 33 53](https://cloud.githubusercontent.com/assets/122434/21499787/25f80db4-cc39-11e6-8a74-6385fb950215.png)