### PR TITLE
Stats : hide "Analysis" page

### DIFF
--- a/routes/statistics.js
+++ b/routes/statistics.js
@@ -25,7 +25,6 @@ module.exports = function (processingStepsMeta) {
 			decorateContext: function () { this.processingStepsMeta = processingStepsMeta; },
 			view: require('../view/statistics-time-per-person')
 		},
-		analysis: require('../view/statistics-analysis'),
 
 		profile: require('../view/user-profile')
 	};

--- a/view/statistics-analysis.js
+++ b/view/statistics-analysis.js
@@ -1,9 +1,0 @@
-'use strict';
-
-exports._parent = require('./statistics-base');
-
-exports['analysis-nav'] = { class: { 'submitted-menu-item-active': true } };
-
-exports['statistics-main'] = function () {
-	// no content yet
-};

--- a/view/statistics-base.js
+++ b/view/statistics-base.js
@@ -8,7 +8,6 @@ exports['submitted-menu'] = function () {
 	li({ id: 'dashboard-nav' }, a({ href: '/' }, _("Dashboard")));
 	li({ id: 'files-nav' }, a({ href: '/files/' }, _("Files")));
 	li({ id: 'time-nav' }, a({ href: '/time/' }, _("Time")));
-	li({ id: 'analysis-nav' }, a({ href: '/analysis/' }, _("Analysis")));
 };
 
 exports['sub-main'] = {


### PR DESCRIPTION
I have never given you the content to put in this page, therefore it is normal to see nothing here. 
I suggest that we hide this page from the menu.
In the future I will come with something great for here as I still believe that it is useful to show stats about the content of the files (like activities of individual traders, etc.).