### PR TITLE
In Statistics ensure legacy date controls

### DIFF
--- a/scripts/generate-app/templates/client/legacy/index.js/statistics.tpl
+++ b/scripts/generate-app/templates/client/legacy/index.js/statistics.tpl
@@ -10,5 +10,6 @@ require('eregistrations/client/legacy/init');
 require('mano-legacy/live/input-mask');
 //Logs client errors to server logs
 require('eregistrations/client/legacy/error-logger');
+require('eregistrations/client/legacy/date-controls');
 
 require('mano-legacy/element#/toggle');


### PR DESCRIPTION
As reported by @vianneyl here: https://github.com/egovernment/eregistrations/issues/1496#issuecomment-269323392

Let's ensure date inputs are replaced with those three input ones (question of ensuring date-controls utility in legacy). IT will give proper inputs in browsers that do not natively support date.