### PR TITLE
Horizontal menu render crashes (race condition)

### DIFF
--- a/view/user-base.js
+++ b/view/user-base.js
@@ -95,6 +95,10 @@ exports.main = function () {
 
 exports._submittedMenu = function () {
 	var user = this.manager || this.user, isOfficialRole;
+	// user.currentRoleResolved may not be resolved yet...
+	if (!user.currentRoleResolved) {
+		return;
+	}
 	if (user.currentRoleResolved === 'statistics') {
 		return [li({ id: 'dashboard-nav' }, a({ href: '/' }, _("Dashboard"))),
 			li({ id: 'files-nav' }, a({ href: '/files/' }, _("Files"))),


### PR DESCRIPTION
There are rare scenarios when some data is loaded slightly later than interface is generated, and it can be the case where we render horizontal menu while `currentRoleResolved` is null, then it crashes here -> https://github.com/egovernment/eregistrations/blob/master/view/user-base.js#L112

This error was reported by client error logger in GT

```
Client & Session Id:
------------------------------------
011z9kqiuslc:818ah5kh7msf


User Agent:
------------------------------------
Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36


UTC Time:
------------------------------------
2017-01-06T16:17:07.583Z


Server Time:
------------------------------------
2017-01-06 17:17:07


Referer:
------------------------------------
https://minegocio.gt/


User Id:
------------------------------------
2rle5m1pnbk


Application Name:
------------------------------------
manager


Application Access Id:
------------------------------------
32rle5m1pnbk.manager


IP:
------------------------------------
181.209.149.105


Location:
------------------------------------
https://minegocio.gt/


Build Stamp:
------------------------------------
2017-01-05T13:03:57.437Z


Message:
------------------------------------
Uncaught TypeError: Cannot read property 'label' of undefined


Source:
------------------------------------
https://d2mv73hs2rqxhz.cloudfront.net/manager.js


Line:
------------------------------------
1


Column:
------------------------------------
1440836


Error Message:
------------------------------------
Cannot read property 'label' of undefined


Error Stack:
------------------------------------
TypeError: Cannot read property 'label' of undefined
    at Object.a._getSubmittedMenuItem (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1440836)
    at Object.a._submittedMenu (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1440705)
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1439430)
    at https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1227335
    at g.exports (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1289819)
    at d.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1287372)
    at Object.a.main (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1439238)
    at b.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:326500)
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:349052)
    at Object.c (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1390206)
    at https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:374572
    at Array.forEach (native)
    at https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:374515
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1389599)
    at l.exports.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1394944)
    at l.exports.b (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:34195)
    at l.exports.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1394824)
    at https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1390623
    at Array.forEach (native)
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1390601)
    at Object.a.(anonymous function) (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1397441)
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:29606)
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1397586)
    at Object.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:29258)
    at d.s (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1085508)
    at d.m (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:440609)
    at d.<anonymous> (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1184397)
    at b (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1085595)
    at Object.program.js (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1086057)
    at e (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1060)
    at h (https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1400)
    at https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1460
    at https://d2mv73hs2rqxhz.cloudfront.net/manager.js:1:1454832


```