### PR TITLE
Stats : space between tabs and content

### DIFF
--- a/css/components/user-forms.css
+++ b/css/components/user-forms.css
@@ -5,9 +5,7 @@
 .user-forms > *:first-child {
 	margin-top: 44px;
 }
-.user-forms > .pills-nav {
-	margin-top: 22px;
-}
+
 .user-forms > form,
 .user-forms > .disabler-range,
 .user-forms > .disabler-range > .disabler-range,

--- a/view/statistics-base.js
+++ b/view/statistics-base.js
@@ -6,6 +6,6 @@ exports['sub-main'] = {
 	class: { content: true },
 	content: function () {
 		ul({ id: 'statistics-sub-menu', class: 'pills-nav' });
-		div({ class: 'statistics-main user-forms', id: 'statistics-main' });
+		div({ class: 'statistics-main blocks-container', id: 'statistics-main' });
 	}
 };


### PR DESCRIPTION
There is too much space below the tabs and before the period selector, it should be reduced (same space should be between the menu and the tabs and between the tabs and the period selector).