### PR TITLE
Notary optimisation : add start service button from the clients table

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -135,7 +135,8 @@ input[type="search"] {
 }
 
 input[type="submit"],
-button[type="submit"] {
+button[type="submit"],
+.button-submit {
 	line-height: 22px;
 	border-radius: 4px;
 	color: var(--white-text);
@@ -145,6 +146,7 @@ button[type="submit"] {
 	font-size: 14px;
 	padding: 4px 10px;
 	cursor: pointer;
+	text-align: center;
 }
 @-moz-document url-prefix() {
 	input[type="submit"],
@@ -158,7 +160,10 @@ input[type="submit"]:focus,
 input[type="submit"]:active,
 button[type="submit"]:hover,
 button[type="submit"]:focus,
-button[type="submit"]:active {
+button[type="submit"]:active,
+.button-submit:hover,
+.button-submit:focus,
+.button-submit:active {
 	color: var(--white-text);
 	background-color: var(--normal-dark-background);
 	outline: none;

--- a/model/user/business-processes.js
+++ b/model/user/business-processes.js
@@ -66,6 +66,24 @@ module.exports = memoize(function (User/* options */) {
 		services: {
 			type: db.Object,
 			nested: true
+		},
+		servicesOpenForNewDraft: {
+			multiple: true,
+			type: db.Base,
+			value: function (_observe) {
+				var db = this.database, result = [];
+
+				db.BusinessProcess.extensions.forEach(function (Bp) {
+					var serviceName;
+					serviceName = Bp.__id__.slice('BusinessProcess'.length);
+					serviceName = serviceName[0].toLowerCase() + serviceName.slice(1);
+					if (_observe(this.services[serviceName]._isOpenForNewDraft)) {
+						result.push(Bp);
+					}
+				}, this);
+
+				return result;
+			}
 		}
 	});
 

--- a/view/manager-business-processes.js
+++ b/view/manager-business-processes.js
@@ -70,16 +70,16 @@ exports._createBpDialog = function (params) {
 								label({ for: derivationSourcesSelectPrefix },
 									_("Select the entity for which you want to start the service"))),
 
-							li({ class: 'input' }),
-							select({ name: 'initialProcess', id: derivationSourcesSelectPrefix },
-								list(derivationSources,
-									function (derivationSource) {
-										return option({ id: derivationSourcesSelectPrefix + derivationSource.__id__,
-											value: derivationSource.__id__ },
-											derivationSource._businessName);
-									}),
-								option({ value: 'notRegistered' }, _("An other business"))
-								)])
+							li({ class: 'input' },
+								select({ name: 'initialProcess', id: derivationSourcesSelectPrefix },
+									list(derivationSources,
+										function (derivationSource) {
+											return option({ id: derivationSourcesSelectPrefix + derivationSource.__id__,
+												value: derivationSource.__id__ },
+												derivationSource._businessName);
+										}),
+									option({ value: 'notRegistered' }, _("An other business"))
+									))])
 					),
 					p(input({ type: 'submit', value: _("Start service") })),
 					legacy('selectMatch', clientSelectPrefix, clientsProcesses)

--- a/view/manager-home.js
+++ b/view/manager-home.js
@@ -2,22 +2,101 @@
 
 'use strict';
 
-var _ = require('mano').i18n.bind('View: Manager');
+var _              = require('mano').i18n.bind('View: Manager')
+  , db             = require('../db')
+  , modalContainer = require('./components/modal-container');
 
 exports._parent = require('./manager');
 
 exports['manager-account-clients'] = { class: { active: true } };
 
+exports._businessProcessesTypes = Function.prototype;
+
+exports._createBpDialog = function (params) {
+	var actionUrl, availableServices, client, derivationSources
+	  , serviceSelectPrefix, derivationSourcesSelectPrefix, clientsProcesses;
+
+	client            = params.client;
+	actionUrl         = params.actionUrl || 'start-new-business-process-by-client/' + client.__id__;
+	availableServices = params.availableServices;
+	serviceSelectPrefix = 'start-new-service-bp-select' + client.__id__;
+	derivationSourcesSelectPrefix = 'derive-new-service-bp-by-user-select-' + client.__id__;
+	derivationSources = this.user.managedBusinessProcesses.filterByKey('canBeDerivationSource',
+		true).and(
+		client.initialBusinessProcesses
+	);
+	clientsProcesses = {};
+	availableServices.filterByKey('isDerivable', true);
+
+	availableServices.forEach(function (BusinessProcess) {
+		if (BusinessProcess.prototype.isDerivable) {
+			if (!clientsProcesses[BusinessProcess.__id__]) {
+				clientsProcesses[BusinessProcess.__id__] = [];
+			}
+			clientsProcesses[BusinessProcess.__id__].push(derivationSourcesSelectPrefix,
+					derivationSourcesSelectPrefix + '-label');
+		}
+	});
+
+	return modalContainer.append(dialog(
+		{ id: client.__id__,
+			class: 'dialog-modal dialog-business-process-derive' },
+		header(
+			h3(_("Start a new service for client ${fullName}",
+				{ fullName: client._fullName }))
+		),
+		section(
+			{ class: 'dialog-body' },
+			_if(availableServices._size, [
+				form({ action: url(actionUrl), method: 'post' },
+					ul(
+						{ class: 'form-elements' },
+						li({ class: 'input' },
+							label({ for: serviceSelectPrefix },
+								_("I want to start the following service"))),
+						li({ class: 'input' },
+							select({ name: 'BusinessProcessId', id: serviceSelectPrefix },
+								list(availableServices,
+									function (BusinessProcess) {
+										return option({ value: BusinessProcess.__id__ },
+											BusinessProcess.prototype.label);
+									}))),
+						li({ class: 'input', id: derivationSourcesSelectPrefix + '-label' },
+								label({ for: derivationSourcesSelectPrefix },
+									_("Select the entity for which you want to start the service"))),
+						li({ class: 'input' },
+							select({ name: 'initialProcess', id: derivationSourcesSelectPrefix },
+								list(derivationSources,
+									function (derivationSource) {
+										return option({
+											value: derivationSource.__id__
+										},
+											derivationSource._businessName);
+									}),
+								option({ value: 'notRegistered' }, _("An other business"))))
+					),
+					p(input({ type: 'submit', value: _("Start service") })),
+					legacy('selectMatch', serviceSelectPrefix, clientsProcesses)
+					)
+			])
+		)
+	));
+};
+
 exports['manager-account-content'] = function () {
 	var manager = this.user
-	  , clients = manager.managedUsers;
+	  , clients = manager.managedUsers
+	  , businessProcessesTypes;
+
+	businessProcessesTypes = exports._businessProcessesTypes.call(this) ||
+		db.BusinessProcess.extensions;
 
 	insert(_if(manager._isManagerActive,
 		[p({ class: 'section-primary-legend' }, _("Here is your list of clients. " +
 			"By clicking on the pen, you will arrive in their Client " +
 			"Account where you will be able to start a service on their " +
 			"name and see all their documents and data")),
-			a({ href: url('new-client'), class: 'button-main' },
+			a({ href: url('new-client'), class: 'button-regular' },
 				_("Add client"))], p({ class: 'section-primary-legend' },
 			_("Your account is currently inactive"))));
 
@@ -28,25 +107,37 @@ exports['manager-account-content'] = function () {
 				thead(tr(
 					th(_("Client linked to this notary account")),
 					th(_("Services started for this client")),
-					_if(manager._isManagerActive, th({ colspan: "2" }))
+					_if(manager._isManagerActive, th({ colspan: "3" }))
 				)),
 				tbody(
 					clients,
 					function (client) {
 						var bpSet = client.initialBusinessProcesses.and(manager.managedBusinessProcesses)
-									.filterByKey('businessName');
+									.filterByKey('businessName')
+						  , availableServices =
+								businessProcessesTypes.and(client.servicesOpenForNewDraft);
+						exports._createBpDialog.call(this,
+							{ availableServices: availableServices, client: client });
 
 						return tr(
 							td(client._fullName),
 
 							td(bpSet.map(function (bp) { return bp.constructor; })._size),
 							_if(manager._isManagerActive,
-								[td(
-									postButton({
-										action: url('clients', client.__id__),
-										value: _("Access the client's account")
-									})
-								),
+								[
+									td(
+										_if(availableServices._size,
+											a({
+												class: 'button-submit',
+												href: "#" + client.__id__
+											}, _("Start a service for this client")))
+									),
+									td(
+										postButton({
+											action: url('clients', client.__id__),
+											value: _("Access the client's account")
+										})
+									),
 									td(
 										_if(client._canManagedUserBeDestroyed,
 											postButton({


### PR DESCRIPTION
Following #1682, this is point number 4 of the notary optimisation.

In the clients table, have a button "Start a service for this client" for each client. That button will be just between the quantities of services started by client and the "Access to the clients account" button. 

<img width="1108" alt="minegocio_gt" src="https://cloud.githubusercontent.com/assets/3383078/20609839/560f8d7a-b257-11e6-94bf-fffe220c06d8.png">

On click on this button, a modale window would open with a choice of services that the notary can run for the client.

This is the less-important issue of notary-optimisation milestone, do it only if easy.