### PR TITLE
Switch business table renders to new query mechanism

### DIFF
--- a/apps-common/query-conf/status.js
+++ b/apps-common/query-conf/status.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+	name: 'status',
+	ensure: function (value) {
+		if (value === 'all') return;
+		if (!value) return 'pending';
+
+		return value;
+	}
+};

--- a/apps/official/query-conf.js
+++ b/apps/official/query-conf.js
@@ -3,6 +3,7 @@
 'use strict';
 
 module.exports = [
+	require('../../apps-common/query-conf/status'),
 	require('../../apps-common/query-conf/search'),
 	require('../../apps-common/query-conf/page')
 ];

--- a/apps/official/query-conf.js
+++ b/apps/official/query-conf.js
@@ -1,0 +1,8 @@
+// Official dedicated search query handler
+
+'use strict';
+
+module.exports = [
+	require('../../apps-common/query-conf/search'),
+	require('../../apps-common/query-conf/page')
+];

--- a/server/business-process-query/business-processes/filter.js
+++ b/server/business-process-query/business-processes/filter.js
@@ -49,6 +49,11 @@ module.exports = exports = function (data, query) {
 			if (bpData.status !== query.status) return;
 		}
 
+//		// Filter by step status
+//		if (query.stepStatus) {
+//			if (!bpData.step)
+//		}
+
 		// Filter by submitter type
 		if (query.submitterType) {
 			if (bpData.submitterType !== query.submitterType) return;

--- a/server/business-process-query/steps/filter.js
+++ b/server/business-process-query/steps/filter.js
@@ -13,6 +13,7 @@ var resolveBpFilterQuery = function (query) {
 		dateFrom: null,
 		dateTo: null,
 		step: null,
+		status: null,
 		pendingAt: null,
 		flowStatus: 'submitted'
 	});
@@ -45,15 +46,12 @@ module.exports = exports = function (data, query) {
 		});
 		stepsData = filteredStepsData;
 	}
-
 	var filteredBpsData = filterBps(data.businessProcesses, resolveBpFilterQuery(query));
-
 	filteredStepsData = new Map();
 	stepsData.forEach(function (stepData, stepShortPath) {
 		var filteredStepData = new Map();
 		filteredStepsData.set(stepShortPath, filteredStepData);
 		stepData.forEach(function (bpStepData, bpId) {
-
 			// Filter any filtered at business process level
 			if (!filteredBpsData.has(bpId)) return;
 
@@ -76,6 +74,10 @@ module.exports = exports = function (data, query) {
 				if (bpStepData.processingDate) {
 					if (bpStepData.processingDate < query.pendingAt) return;
 				}
+			}
+
+			if (query.status) {
+				if (bpStepData.status !== query.status) return;
 			}
 
 			// Custom filter

--- a/server/routes/official.js
+++ b/server/routes/official.js
@@ -15,10 +15,10 @@ var assign                    = require('es5-ext/object/assign')
   , sortData                  = require('../../utils/query/sort')
   , getPage                   = require('../../utils/query/get-page')
   , QueryHandler              = require('../../utils/query-handler')
-//TODO console.log('CLEAN UP BELOW LISTS')
-  , listProperties            = require('../../apps/inspector/list-properties')
-  , listComputedProperties    = require('../../apps/inspector/list-computed-properties')
-  , queryHandlerConf          = require('../../apps/inspector/query-conf')
+  , listProperties            = require('../../apps/official/business-process-list-properties')
+  , listComputedProperties    =
+			require('../../apps/official/business-process-list-computed-properties')
+  , queryHandlerConf          = require('../../apps/official/query-conf')
   , getStatsQueryHandlerConf  = require('../../apps/statistics/get-query-conf')
   , getReductionTemplate      =
 		require('../business-process-query/utils/get-time-reduction-template')
@@ -108,15 +108,11 @@ module.exports = exports = function (config/*, options */) {
 		},
 		'get-processing-time-data': function (query) {
 			if (!statsOverviewQueryHandler) return null;
-			return resolveHandler(this.req)(function (handler) {
-				var userId = this.req.$user;
-				if (!handler.roleName) return;
-				query.step = handler.roleName;
+			var userId = this.req.$user;
 
-				return statsOverviewQueryHandler.resolve(query)(function (query) {
-					return getStatsOverviewData(query, userId);
-				});
-			}.bind(this));
+			return statsOverviewQueryHandler.resolve(query)(function (query) {
+				return getStatsOverviewData(query, userId);
+			});
 		},
 		'business-process-status-log-print': {
 			headers: {

--- a/server/routes/official.js
+++ b/server/routes/official.js
@@ -1,316 +1,40 @@
-// Official roles GET controllers
-
 'use strict';
 
-var aFrom                          = require('es5-ext/array/from')
-  , and                            = require('es5-ext/array/#/intersection')
-  , flatten                        = require('es5-ext/array/#/flatten')
-  , remove                         = require('es5-ext/array/#/remove')
-  , uniq                           = require('es5-ext/array/#/uniq')
-  , customError                    = require('es5-ext/error/custom')
-  , constant                       = require('es5-ext/function/constant')
-  , isNaturalNumber                = require('es5-ext/number/is-natural')
-  , toNaturalNumber                = require('es5-ext/number/to-pos-integer')
-  , assign                         = require('es5-ext/object/assign')
-  , normalizeOptions               = require('es5-ext/object/normalize-options')
-  , toArray                        = require('es5-ext/object/to-array')
-  , ensureCallable                 = require('es5-ext/object/valid-callable')
-  , ensureObject                   = require('es5-ext/object/valid-object')
-  , ensureString                   = require('es5-ext/object/validate-stringifiable-value')
-  , includes                       = require('es5-ext/string/#/contains')
-  , uncapitalize                   = require('es5-ext/string/#/uncapitalize')
-  , Set                            = require('es6-set')
-  , d                              = require('d')
-  , deferred                       = require('deferred')
-  , memoize                        = require('memoizee')
-  , serializeValue                 = require('dbjs/_setup/serialize/value')
-  , unserializeValue               = require('dbjs/_setup/unserialize/value')
-  , ObservableSet                  = require('observable-set/primitive')
-  , mano                           = require('mano')
-  , roleNameMap                    = require('mano/lib/server/user-role-name-map')
-  , getStatsQueryHandlerConf       = require('../../apps/statistics/get-query-conf')
-  , QueryHandler                   = require('../../utils/query-handler')
-  , defaultItemsPerPage            = require('../../conf/objects-list-items-per-page')
-  , getDbSet                       = require('../utils/get-db-set')
-  , getDbArray                     = require('../utils/get-db-array')
-  , getIndexMap                    = require('../utils/get-db-sort-index-map')
-  , businessProcessStoragesPromise = require('../utils/business-process-storages')
-  , idToStorage                    = require('../utils/business-process-id-to-storage')
-  , getData                        = require('../business-process-query/get-data')
-  , filterSteps                    = require('../business-process-query/steps/filter')
-  , reduceSteps                    = require('../business-process-query/steps/reduce-time')
-  , statusLogPrintPdfRenderer      = require('../pdf-renderers/business-process-status-log-print')
-  , getBaseRoutes                  = require('./authenticated')
+var assign                    = require('es5-ext/object/assign')
+  , ensureObject              = require('es5-ext/object/valid-object')
+  , startsWith                = require('es5-ext/string/#/starts-with')
+  , customError               = require('es5-ext/error/custom')
+  , ensureDriver              = require('dbjs-persistence/ensure-driver')
+  , getBaseRoutes             = require('./authenticated')
+  , getData                   = require('../business-process-query/get-data')
+  , reduceSteps               = require('../business-process-query/steps/reduce-time')
+  , filterSteps               = require('../business-process-query/steps/filter')
+  , getViewRecords            = require('../business-process-query/get-view-records')
+  , anyIdToStorage            = require('../utils/any-id-to-storage')
+  , statusLogPrintPdfRenderer = require('../pdf-renderers/business-process-status-log-print')
+  , sortData                  = require('../../utils/query/sort')
+  , getPage                   = require('../../utils/query/get-page')
+  , QueryHandler              = require('../../utils/query-handler')
+//TODO console.log('CLEAN UP BELOW LISTS')
+  , listProperties            = require('../../apps/inspector/list-properties')
+  , listComputedProperties    = require('../../apps/inspector/list-computed-properties')
+  , queryHandlerConf          = require('../../apps/inspector/query-conf')
+  , getStatsQueryHandlerConf  = require('../../apps/statistics/get-query-conf')
+  , getReductionTemplate      =
+		require('../business-process-query/utils/get-time-reduction-template')
+  , memoize                   = require('memoizee');
 
-  , hasBadWs = RegExp.prototype.test.bind(/\s{2,}/)
-  , compareStamps = function (a, b) { return a.stamp - b.stamp; }
-  , isArray = Array.isArray, slice = Array.prototype.slice
-  , ceil = Math.ceil, create = Object.create
-  , defineProperty = Object.defineProperty, stringify = JSON.stringify
-  , businessProcessStorages, businessProcessStorageNames;
-
-var getReductionTemplate = require('../business-process-query/utils/get-time-reduction-template');
-
-businessProcessStoragesPromise.done(function (storages) {
-	businessProcessStorages = storages;
-	businessProcessStorageNames = storages.map(function (storage) { return storage.name; });
-});
-
-var compareIndexMeta = function (meta1, meta2) {
-	return meta1.name.localeCompare(meta2.name) || meta1.value.localeCompare(meta2.value);
-};
-
-// Business processes table query handler
-var getTableQueryHandler = function (statusMap) {
-	var queryHandler = new QueryHandler(exports.tableQueryConf);
-	queryHandler._statusMap = statusMap;
-	return queryHandler;
-};
-
-// Single business process full data query handler
-var getBusinessProcessQueryHandler = function (indexName, indexValue) {
-	return new QueryHandler([
-		{
-			name: 'id',
-			ensure: function (ownerId) {
-				if (!ownerId) throw new Error("Missing id");
-				return idToStorage(ownerId)(function (storage) {
-					if (!storage) return null;
-					return storage.getComputed(ownerId + '/' + indexName)(function (data) {
-						if (!data || (data.value !== (indexValue || '11'))) return null;
-						return ownerId;
-					});
-				});
-			}
-		}
-	]);
-};
-
-var getFilteredSet = memoize(function (baseSet, filterString, storages) {
-	var set = new ObservableSet(), baseSetListener, indexListener
-	  , def = deferred(), count = 0, isInitialized = false;
-	var filter = function (ownerId, data) {
-		var value = unserializeValue(data.value);
-		if (value && includes.call(value, filterString)) set.add(ownerId);
-		else set.delete(ownerId);
-	};
-	var findAndFilter = function (ownerId) {
-		return idToStorage(ownerId)(function (storage) {
-			if (!storage) return;
-			return storage.getComputed(ownerId + '/searchString').aside(function (data) {
-				if (!baseSet.has(ownerId)) return;
-				if (!data) return;
-				filter(ownerId, data);
-			});
+var businessProcessQueryHandler = new QueryHandler([{
+	name: 'id',
+	ensure: function (value) {
+		if (!value) throw new Error("Missing id");
+		return anyIdToStorage(value)(function (storage) {
+			if (!storage) return null;
+			if (!startsWith.call(storage.name, 'businessProcess')) return null;
+			return value;
 		});
-	};
-	baseSet.on('change', baseSetListener = function (event) {
-		if (event.type === 'add') findAndFilter(event.value).done();
-		else set.delete(event.value);
-	});
-	indexListener = function (event) {
-		if (!baseSet.has(event.ownerId)) return;
-		filter(event.ownerId, event.data);
-	};
-	storages.forEach(function (storage) { storage.on('key:searchString', indexListener); });
-	baseSet.forEach(function (ownerId) {
-		++count;
-		findAndFilter(ownerId).done(function () {
-			if (!--count && isInitialized) def.resolve(set);
-		});
-	});
-	isInitialized = true;
-	if (!count) def.resolve(set);
-	defineProperty(set, '_dispose', d(function () {
-		baseSet.off(baseSetListener);
-		storages.forEach(function (storage) { storage.off('key:searchString', indexListener); });
-	}));
-	return def.promise;
-}, { length: 2, max: 1000, dispose: function (set) { set._dispose(); } });
-
-var getDbArrayLru = memoize(function (set, sortIndexName, storages) {
-	var arr = [], itemsMap = getIndexMap(storages, sortIndexName)
-	  , count = 0, isInitialized = false, def = deferred(), setListener, itemsListener;
-	var add = function (ownerId) {
-		var promise;
-		if (itemsMap[ownerId]) {
-			promise = deferred(itemsMap[ownerId]);
-		} else {
-			promise = idToStorage(ownerId)(function (storage) {
-				if (!storage) return;
-				return storage.getComputed(ownerId + '/' + sortIndexName);
-			});
-		}
-		return promise.aside(function (data) {
-			if (!set.has(ownerId)) return;
-			if (!itemsMap[ownerId]) itemsMap[ownerId] = { id: ownerId, stamp: data ? data.stamp : 0 };
-			arr.push(itemsMap[ownerId]);
-			if (def.resolved) arr.sort(compareStamps);
-		});
-	};
-	set.on('change', setListener = function (event) {
-		if (event.type === 'add') add(event.value).done();
-		else remove.call(arr, itemsMap[event.value]);
-	});
-	itemsMap.on('update', itemsListener = function (event) {
-		if (!set.has(event.ownerId)) return;
-		if (def.resolved) arr.sort(compareStamps);
-	});
-	set.forEach(function (ownerId) {
-		++count;
-		add(ownerId).done(function () {
-			if (!--count && isInitialized) def.resolve(arr.sort(compareStamps));
-		});
-	});
-	isInitialized = true;
-	if (!count) def.resolve(arr.sort(compareStamps));
-	defineProperty(set, '_dispose', d(function () {
-		set.off(setListener);
-		itemsMap.off(itemsListener);
-	}));
-	return def.promise;
-}, { length: 2, max: 1000, dispose: function (arr) { arr._dispose(); } });
-
-var initializeHandler = function (conf) {
-	conf = normalizeOptions(ensureObject(conf));
-
-	var roleName            = ensureString(conf.roleName)
-	  , statusMap           = ensureObject(conf.statusMap)
-	  , statusIndexName     = ensureString(conf.statusIndexName)
-	  , allIndexName        = conf.allIndexName || statusMap.all.indexName
-	  , bpListProps         = new Set(aFrom(conf.listProperties))
-	  , bpListComputedProps = conf.listComputedProperties && aFrom(conf.listComputedProperties)
-	  , tableQueryHandler   = getTableQueryHandler(statusMap)
-	  , itemsPerPage        = toNaturalNumber(conf.itemsPerPage) || defaultItemsPerPage
-	  , businessProcessQueryHandler = getBusinessProcessQueryHandler(allIndexName, conf.allIndexValue)
-	  , storageName, storages;
-
-	if (!bpListComputedProps) bpListComputedProps = [allIndexName];
-	else bpListComputedProps.push(allIndexName);
-
-	if (conf.storageName != null) {
-		storageName = conf.storageName;
-		if (isArray(storageName)) {
-			storages = storageName.map(function (storageName) {
-				return mano.dbDriver.getStorage(ensureString(storageName));
-			});
-		} else {
-			storages = [mano.dbDriver.getStorage(storageName)];
-		}
-	} else {
-		storageName = businessProcessStorageNames;
-		storages = businessProcessStorages;
 	}
-
-	var getTableData = memoize(function (query) {
-		var indexMeta = exports.getIndexMeta(query, statusMap), promise;
-
-		if (isArray(indexMeta)) {
-			promise = deferred.map(indexMeta.sort(compareIndexMeta), function (indexMeta) {
-				return getDbSet(storages, 'computed', indexMeta.name, indexMeta.value);
-			})(function (sets) {
-				return aFrom(sets).reduce(function (set1, set2) { return set1.and(set2); });
-			});
-		} else {
-			promise = getDbSet(storages, 'computed', indexMeta.name, indexMeta.value);
-		}
-
-		if (query.assignedTo) {
-			promise = promise.then(function (baseSet) {
-				return getDbSet(storages, 'direct', conf.assigneePath, '7' +
-					query.assignedTo)(function (set) { return baseSet.and(set); });
-			});
-		}
-
-		return promise(function (baseSet) {
-			if (!query.search) return getDbArray(baseSet, storages, 'computed', allIndexName);
-			return deferred.map(query.search.split(/\s+/).sort(), function (value) {
-				return getFilteredSet(baseSet, value, storages)(function (set) {
-					return getDbArrayLru(set, allIndexName, storages);
-				});
-			})(function (arrays) {
-				if (arrays.length === 1) return arrays[0];
-
-				return arrays.reduce(function (current, next, index) {
-					if (index === 1) current = aFrom(current);
-					return and.call(current, next);
-				}).sort(compareStamps);
-			});
-		})(function (arr) {
-			var size = arr.length, pageCount, offset, computedEvents, directEvents, statuses, statusMap;
-			if (!size) return { size: size };
-			pageCount = ceil(size / itemsPerPage);
-			if (query.page > pageCount) return { size: size };
-
-			// Pagination
-			offset = (query.page - 1) * itemsPerPage;
-			arr = slice.call(arr, offset, offset + itemsPerPage);
-			if (bpListComputedProps) {
-				computedEvents = deferred.map(arr, function (data) {
-					var objId = data.id;
-					return deferred.map(bpListComputedProps, function (keyPath) {
-						return idToStorage(objId)(function (storage) {
-							if (!storage) return;
-							return storage.getComputed(objId + '/' + keyPath)(function (data) {
-								if (!data) return;
-								if (isArray(data.value)) {
-									return data.value.map(function (data) {
-										var key = data.key ? '*' + data.key : '';
-										return data.stamp + '.' + objId + '/' + keyPath + key + '.' + data.value;
-									});
-								}
-								return data.stamp + '.' + objId + '/' + keyPath + '.' + data.value;
-							});
-						});
-					});
-				});
-			} else {
-				computedEvents = [];
-			}
-			directEvents = deferred.map(arr, function (data) {
-				return idToStorage(data.id)(function (storage) {
-					if (!storage) return null;
-					return storage.getObject(data.id, { keyPaths: bpListProps })(function (datas) {
-						return datas.map(function (data) {
-							return data.data.stamp + '.' + data.id + '.' + data.data.value;
-						});
-					});
-				});
-			});
-			if (!query.status) {
-				statusMap = create(null);
-				statuses = deferred.map(arr, function (data) {
-					return idToStorage(data.id)(function (storage) {
-						if (!storage) return null;
-						return storage.getComputed(data.id + '/' + statusIndexName).aside(function (record) {
-							statusMap[data.id] = record ? unserializeValue(record.value) : null;
-						});
-					});
-				})(statusMap);
-			}
-			return deferred(directEvents, computedEvents, statuses)
-				.spread(function (directEvents, computedEvents, statusMap) {
-					return {
-						view: arr.map(function (data) { return data.stamp + '.' + data.id; }).join('\n'),
-						size: size,
-						data: flatten.call([directEvents, computedEvents]).filter(Boolean),
-						statusMap: statusMap
-					};
-				});
-		});
-	}, {
-		normalizer: function (args) { return String(toArray(args[0], null, null, true)); },
-		maxAge: 10 * 1000
-	});
-
-	return {
-		tableQueryHandler: tableQueryHandler,
-		getTableData: getTableData,
-		businessProcessQueryHandler: businessProcessQueryHandler,
-		roleName: roleName,
-		assigneePath: conf.assigneePath
-	};
-};
+}]);
 
 var getStatsOverviewData = memoize(function (query, userId, statsHandlerOpts) {
 	var processingStepsMeta = statsHandlerOpts.processingStepsMeta;
@@ -329,89 +53,59 @@ var getStatsOverviewData = memoize(function (query, userId, statsHandlerOpts) {
 	maxAge: 1000 * 60 * 60
 });
 
-module.exports = exports = function (mainConf/*, options */) {
-	var resolveHandler, options, stepShortPathResolve, getHandlerByRole
-	  , recentlyVisitedContextName, decorateQuery, statsOverviewQueryHandler, statsHandlerOpts;
+module.exports = exports = function (config/*, options */) {
+	var driver                 = ensureDriver(ensureObject(config).driver)
+	  , processingStepsMeta    = ensureObject(config.processingStepsMeta)
+	  , queryHandler           = new QueryHandler(queryHandlerConf)
+	  , options, statsHandlerOpts, statsOverviewQueryHandler;
 	options = Object(arguments[1]);
-	recentlyVisitedContextName = options.recentlyVisitedContextName;
 
-	/**
-	 * This is to safeguard older systems which don't use this functionality
-	 * the flag is not mandatory, so only setup if you don't want this configured in a system
-	 * */
-	if (options.processingStepsMeta) {
-		statsHandlerOpts = {
-			processingStepsMeta: ensureObject(options.processingStepsMeta),
-			db: require('mano').db,
-			driver: require('mano').dbDriver
-		};
+	getData(driver, processingStepsMeta).done();
 
-		statsOverviewQueryHandler = new QueryHandler(getStatsQueryHandlerConf(statsHandlerOpts));
-	}
-	if (options.decorateQuery != null) decorateQuery = ensureCallable(options.decorateQuery);
-	if (isArray(mainConf)) {
-		resolveHandler = (function () {
-			var map = mainConf.reduce(function (map, conf) {
-				map[conf.roleName] = initializeHandler(conf);
-				return map;
-			}, create(null));
-			getHandlerByRole = function (stepShortPath) {
-				var handler;
-				if (stepShortPath) {
-					handler = map[stepShortPath];
-				}
-				if (!handler) {
-					throw new Error("Cannot resolve conf for step path: " + stringify(stepShortPath));
-				}
-				return handler;
-			};
-			if (options.resolveConf && (typeof options.resolveConf === 'function')) {
-				stepShortPathResolve = function (req) {
-					return deferred(options.resolveConf(req)).then(getHandlerByRole);
-				};
-			} else {
-				stepShortPathResolve = function (req) {
-					return roleNameMap.get(req.$user)(function (roleName) {
-						if (!roleName) return;
-						roleName = unserializeValue(roleName);
-						return getHandlerByRole(uncapitalize.call(roleName.slice('official'.length)));
-					});
-				};
-			}
-			return function (req) {
-				return businessProcessStoragesPromise(function () { return stepShortPathResolve(req); });
-			};
-		}());
-	} else {
-		resolveHandler = constant(businessProcessStoragesPromise(function () {
-			return initializeHandler(mainConf);
-		}));
-	}
+	statsHandlerOpts = {
+		processingStepsMeta: ensureObject(processingStepsMeta),
+		db: require('mano').db,
+		driver: require('mano').dbDriver
+	};
+
+	statsOverviewQueryHandler = new QueryHandler(getStatsQueryHandlerConf(statsHandlerOpts));
+
 	return assign({
-		'get-business-processes-view': function (query) {
-			var userId = this.req.$user;
-			return resolveHandler(this.req)(function (handler) {
-				// Get snapshot of business processes table page
-				return handler.tableQueryHandler.resolve(query)(function (query) {
-					return deferred(decorateQuery && decorateQuery(query, this.req))(function () {
-						if (handler.assigneePath) {
-							query.assignedTo = userId;
-						}
-						return handler.getTableData(query);
-					});
-				}.bind(this));
-			}.bind(this));
+		'get-data': function (query) {
+			return queryHandler.resolve(query)(function (query) {
+				return getData(driver, processingStepsMeta);
+			})(function (data) {
+				var fullSize;
+
+				data = sortData(
+					filterSteps(data.businessProcesses, query),
+					function (bpA, bpB) {
+						return bpA.createdDateTime.getTime() - bpB.createdDateTime.getTime();
+					}
+				);
+
+				if (!data.length) {
+					return { size: 0, view: [] };
+				}
+
+				fullSize = data.length;
+
+				data = getPage(data, query.page);
+
+				return getViewRecords(data, listProperties, listComputedProperties)(function (result) {
+					result.size = fullSize;
+
+					return result;
+				});
+			});
 		},
 		'get-business-process-data': function (query) {
-			return resolveHandler(this.req)(function (handler) {
-				// Get full data of one of the business processeses
-				return handler.businessProcessQueryHandler.resolve(query)(function (query) {
-					var recordId;
-					if (!query.id) return { passed: false };
-					recordId = this.req.$user + '/recentlyVisited/businessProcesses/' +
-						(recentlyVisitedContextName || handler.roleName) + '*7' + query.id;
-					return mano.dbDriver.getStorage('user').store(recordId, '11')({ passed: true });
-				}.bind(this));
+			// Get full data of one of the business processeses
+			return businessProcessQueryHandler.resolve(query)(function (query) {
+				var recordId;
+				if (!query.id) return { passed: false };
+				recordId = this.req.$user + '/recentlyVisited/businessProcesses/inspector*7' + query.id;
+				return driver.getStorage('user').store(recordId, '11')({ passed: true });
 			}.bind(this));
 		},
 		'get-processing-time-data': function (query) {
@@ -433,57 +127,13 @@ module.exports = exports = function (mainConf/*, options */) {
 			},
 			controller: function (query) {
 				var appName = this.req.$appName;
-				return resolveHandler(this.req)(function (handler) {
-					// Get full data of one of the business processeses
-					return handler.businessProcessQueryHandler.resolve(query)(function (query) {
-						if (!query.id) throw customError("Not Found", { statusCode: 404 });
-						return statusLogPrintPdfRenderer(query.id, { streamable: true,
-							appName: appName });
-					});
+				// Get full data of one of the business processeses
+				return businessProcessQueryHandler.resolve(query)(function (query) {
+					if (!query.id) throw customError("Not Found", { statusCode: 404 });
+					return statusLogPrintPdfRenderer(query.id, { streamable: true,
+						appName: appName });
 				});
 			}
 		}
 	}, getBaseRoutes());
 };
-
-exports.getIndexMeta = function (query, meta) {
-	var status = query.status || 'all';
-
-	return {
-		name: meta[status].indexName,
-		value: serializeValue(meta[status].indexValue)
-	};
-};
-
-exports.tableQueryConf = [{
-	name: 'status',
-	ensure: function (value) {
-		if (!value) return;
-		if (!this._statusMap[value]) {
-			throw new Error("Unreconized status value " + stringify(value));
-		}
-		if (value === 'all') throw new Error("Unexpected default key status");
-		return value;
-	}
-}, {
-	name: 'search',
-	ensure: function (value) {
-		if (!value) return;
-		if (value.toLowerCase() !== value) throw new Error("Unexpected search value");
-		if (hasBadWs(value)) throw new Error("Unexpected search value");
-		if (value !== uniq.call(value.split(/\s/)).join(' ')) {
-			throw new Error("Unexpected search value");
-		}
-		return value;
-	}
-}, {
-	name: 'page',
-	ensure: function (value) {
-		var num;
-		if (isNaN(value)) throw new Error("Unrecognized page value " + stringify(value));
-		num = Number(value);
-		if (!isNaturalNumber(num)) throw new Error("Unreconized page value " + stringify(value));
-		if (!num) throw new Error("Unexpected page value " + stringify(value));
-		return value;
-	}
-}];

--- a/view/components/business-processes-table/manager.js
+++ b/view/components/business-processes-table/manager.js
@@ -1,131 +1,33 @@
-// Business process dedicated list manager
-// (used to handle business processes table in official roles)
+// Inspector dedicated list manager
 
 'use strict';
 
-var includes        = require('es5-ext/array/#/contains')
-  , toNaturalNumber = require('es5-ext/number/to-pos-integer')
-  , toArray         = require('es5-ext/object/to-array')
-  , ensureObject    = require('es5-ext/object/valid-object')
-  , ensureCallable  = require('es5-ext/object/valid-callable')
-  , ensureString    = require('es5-ext/object/validate-stringifiable-value')
+var toNaturalNumber = require('es5-ext/number/to-pos-integer')
   , d               = require('d')
-  , memoize         = require('memoizee/plain')
   , db              = require('mano').db
   , getData         = require('mano/lib/client/xhr-driver').get
-  , getSearchFilter = require('../../../utils/get-search-filter')
-  , ListManager     = require('../objects-table/manager')
-  , resolveList     = require('../objects-table/resolve-list')
+  , ListManager     = require('../objects-table-simple/manager')
 
   , defineProperties = Object.defineProperties, BusinessProcess = db.BusinessProcess;
 
-require('memoizee/ext/max-age');
-
-var getViewData = function (query) {
-	return getData('/get-business-processes-view/', query).aside(function (result) {
-		if (!result.data) return;
-		result.data.forEach(function (eventStr) { db.unserializeEvent(eventStr, 'server-temporary'); });
-	});
-};
-
 var BusinessProcessesManager = module.exports = function (conf) {
-	var user = db.User.validate(ensureObject(conf).user)
-	  , stepShortPath = ensureString(conf.roleName)
-	  , viewKeyPath = conf.viewKeyPath
-	  , statusMap = ensureObject(conf.statusMap)
-	  , getOrderIndex = ensureCallable(conf.getOrderIndex)
-	  , searchFilter = getSearchFilter
-	  , itemsPerPage = toNaturalNumber(conf.itemsPerPage)
-	  , businessProcesses;
+	var itemsPerPage  = toNaturalNumber(conf.itemsPerPage);
 
 	if (itemsPerPage) this.itemsPerPage = itemsPerPage;
-	if (viewKeyPath) {
-		businessProcesses = db.views.businessProcesses.resolveSKeyPath(viewKeyPath).value;
-	} else {
-		businessProcesses = db.views.businessProcesses.getBySKeyPath(stepShortPath);
-	}
 
-	if (!businessProcesses) {
-		throw new Error("Cannot resolve table view for " +
-			JSON.stringify(viewKeyPath || stepShortPath));
-	}
 	defineProperties(this, {
-		_fullItems: d(user.recentlyVisited.businessProcesses
-			.getBySKeyPath(conf.fullItemsRoleName || stepShortPath)),
-		_canItemBeApplicable: d((conf.canItemBeApplicable != null)
-			? ensureCallable(conf.canItemBeApplicable) : null),
-		_statusViews: d(businessProcesses),
-		_statusMap: d(statusMap),
-		_getItemOrderIndex: d(getOrderIndex),
-		_getSearchFilter: d(searchFilter),
-		_queryExternal: d(memoize(getViewData, {
-			normalizer: function (args) { return String(toArray(args[0], null, null, true)); },
-			maxAge: 10 * 1000
-		}))
+		_queryExternal: d(function (query) {
+			return getData('/get-data/', query).aside(function (result) {
+				if (!result.data) return;
+				result.data.forEach(function (eventStr) {
+					db.unserializeEvent(eventStr, 'server-temporary');
+				});
+			});
+		})
 	});
 };
 
 BusinessProcessesManager.prototype = Object.create(ListManager.prototype, {
 	constructor: d(BusinessProcessesManager),
-	_type: d(BusinessProcess),
-
-	// Characterics that needs to be provided per system/user:
-	_fullItems: d(null),
-	_statusViews: d(null),
-	_statusMap: d(null),
-	_getItemOrderIndex: d(null),
-	_getSearchFilter: d(null),
-
-	_isExternalQuery: d(function (query) {
-		// When we have all the items, we don't need to query server
-		if (this._statusViews[query.status || 'all'].totalSize <= this.itemsPerPage) return false;
-		// If it's not about first page, it's only server that knows
-		if (query.page > 1) return true;
-		// If it's purely a first page of a status, we know
-		return this._modifiers.some(function (mod) {
-			return (mod.name !== 'status') && query[mod.name];
-		});
-	}),
-	_isItemApplicable: d(function (item, query) {
-		if (this._fullItems.has(item)) {
-			if (this._canItemBeApplicable && !this._canItemBeApplicable(item, query)) return false;
-		}
-		if (!this._statusMap[query.status || 'all'].data.has(item)) return false;
-		if (!query.search) return true;
-		return query.search.split(/\s+/).every(function (value) {
-			return this._getSearchFilter(value)(item);
-		}, this);
-	}),
-	// Modifiers (used only in case of non-external list resolution)
-	_modifiers: d([
-		{
-			name: 'status',
-			required: true,
-			process: function (ignore, query) {
-				var view = this._statusViews[query.status || 'all']
-				  , list = this._resolveList({ view: view.get(1), size: view.totalSize }, query);
-
-				return {
-					list: list,
-					size: (view.totalSize < this.itemsPerPage) ? list.length : view.totalSize
-				};
-			}
-		},
-		{
-			name: 'search',
-			process: function (data, query) {
-				var value = query.search.split(/\s+/), list = data.list, result;
-				result = list.filter(this._getSearchFilter(value.shift()));
-				if (value.length) {
-					result = value.reduce(function (result, value) {
-						return result.filter(function (item) {
-							return includes.call(this, item);
-						}, list.filter(this._getSearchFilter(value)));
-					}.bind(this), result);
-				}
-				return { list: result, size: result.length };
-			}
-		}
-	]),
-	_resolveList: d(resolveList)
+	_type: d(BusinessProcess)
 });

--- a/view/components/business-processes-table/setup-query-handler.js
+++ b/view/components/business-processes-table/setup-query-handler.js
@@ -1,66 +1,17 @@
-// Business process dedicated search query handler
-// (used to handle business processes table in official roles)
+// Inspector dedicated search query handler
 
 'use strict';
 
-var uniq              = require('es5-ext/array/#/uniq')
-  , customError       = require('es5-ext/error/custom')
-  , isNaturalNumber   = require('es5-ext/number/is-natural')
-  , findKey           = require('es5-ext/object/find-key')
-  , appLocation       = require('mano/lib/client/location')
+var appLocation       = require('mano/lib/client/location')
   , setupQueryHandler = require('../../../utils/setup-client-query-handler')
-
-  , wsRe = /\s{2,}/g
-  , ceil = Math.ceil, stringify = JSON.stringify;
+  , queryConf         = require('../../../apps/official/query-conf');
 
 module.exports = exports = function (listManager/*, pathname*/) {
-	var queryHandler = setupQueryHandler(exports.conf, appLocation, arguments[1] || '/')
-	  , statusMap = listManager._statusMap;
-	queryHandler._statusMap = statusMap;
-	queryHandler._statusViews = listManager._statusViews;
-	queryHandler._statusMapDefaultKey = findKey(statusMap, function (data) { return data.default; });
+	var queryHandler = setupQueryHandler(queryConf, appLocation, arguments[1] || '/');
+
 	queryHandler._itemsPerPage = listManager.itemsPerPage;
 	queryHandler._listManager = listManager;
 	queryHandler.on('query', function (query) { listManager.update(query); });
+
 	return queryHandler;
 };
-exports.conf = [
-	{
-		name: 'status',
-		ensure: function (value) {
-			if (!value) return this._statusMapDefaultKey;
-			if (!this._statusMap[value]) throw new Error("Unreconized status value " + stringify(value));
-			return (value === 'all') ? null : value;
-		}
-	},
-	{
-		name: 'search',
-		ensure: function (value) {
-			var expected;
-			if (!value) return;
-			expected = value.toLowerCase().replace(wsRe, ' ');
-			if (value !== expected) {
-				throw customError("Non normative search value", { fixedQueryValue: expected });
-			}
-			expected = uniq.call(expected.split(/\s/)).join(' ');
-			if (value !== expected) {
-				throw customError("Non normative search value", { fixedQueryValue: expected });
-			}
-			return value;
-		}
-	},
-	{
-		name: 'page',
-		ensure: function (value, query) {
-			var num, pageCount;
-			if (value == null) return '1';
-			if (isNaN(value)) throw new Error("Unrecognized page value " + stringify(value));
-			num = Number(value);
-			if (!isNaturalNumber(num)) throw new Error("Unreconized page value " + stringify(value));
-			if (num <= 1) throw new Error("Unexpected page value " + stringify(value));
-			pageCount = ceil(this._statusViews[query.status || 'all'].totalSize / this._itemsPerPage);
-			if (num > pageCount) throw new Error("Page value overflow");
-			return value;
-		}
-	}
-];


### PR DESCRIPTION
Let's switch to fully Ajax independent table render, that's based on `server/business-process-query`

It means we will no longer rely on reactive views, and on each load we will via ajax call retrieve needed data.

Still (reactive) views will remain to support Pending counts in horizontal menu bar

In this issue we will cover all business processes table so table for:
- all official roles
- dispatcher

(we do not touch supervisor as it's "deprecated" and will be removed)
