### PR TITLE
Additional sanity check for certificate status resolution

### DIFF
--- a/model/document.js
+++ b/model/document.js
@@ -116,6 +116,7 @@ module.exports = memoize(function (db) {
 		},
 		// Status of certificate
 		status: { type: CertificateStatus, value: function (_observe) {
+			if (!_observe(this.master.certificates.applicable).has(this)) return;
 			if (_observe(this.master._isApproved)) return 'approved';
 			if (_observe(this.master._isRejected)) return 'rejected';
 			if (!this.processingStep) return;


### PR DESCRIPTION
We should make sure that certificate is applicable before blindly relying on  for status.