### PR TITLE
Stats: Tables: Roles/Operators: HTML view

### DIFF
--- a/apps-common/query-conf/step.js
+++ b/apps-common/query-conf/step.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var processingStepsMeta = require('../../processing-steps-meta');
+
+module.exports = function (/* opts */) {
+	var opts = Object(arguments[0]);
+	return {
+		name: 'step',
+		ensure: function (value) {
+			if (!value) {
+				return opts.defaultStep || value;
+			}
+			if (!processingStepsMeta[value]) {
+				throw new Error("Unrecognized step value " + JSON.stringify(value));
+			}
+			return value;
+		}
+	};
+};

--- a/apps/statistics/flow-query-operators-conf.js
+++ b/apps/statistics/flow-query-operators-conf.js
@@ -6,6 +6,7 @@ module.exports = [
 	require('../../apps-common/query-conf/service'),
 	require('../../apps-common/query-conf/mode'),
 	require('../../apps-common/query-conf/step')({ defaultStep: 'revision' }),
+	require('../../apps-common/query-conf/page'),
 	{
 		name: 'processor',
 		ensure: function (value) {

--- a/apps/statistics/flow-query-operators-conf.js
+++ b/apps/statistics/flow-query-operators-conf.js
@@ -1,16 +1,21 @@
 'use strict';
 
+var processingSteps = require('../../processing-steps-meta');
+
 module.exports = [
 	require('../../apps-common/query-conf/date-from'),
 	require('../../apps-common/query-conf/date-to'),
 	require('../../apps-common/query-conf/service'),
 	require('../../apps-common/query-conf/mode'),
-	require('../../apps-common/query-conf/step')({ defaultStep: 'revision' }),
+	require('../../apps-common/query-conf/step')({ defaultStep: Object.keys(processingSteps)[0] }),
 	require('../../apps-common/query-conf/page'),
+	require('../../apps-common/query-conf/certificate'),
 	{
 		name: 'processor',
 		ensure: function (value) {
 			if (!value) return;
+			// TODO: add user some validation after this is addressed
+			// https://github.com/egovernment/eregistrations/issues/1641
 
 			return value;
 		}

--- a/apps/statistics/flow-query-operators-conf.js
+++ b/apps/statistics/flow-query-operators-conf.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = [
+	require('../../apps-common/query-conf/date-from'),
+	require('../../apps-common/query-conf/date-to'),
+	require('../../apps-common/query-conf/service'),
+	require('../../apps-common/query-conf/mode'),
+	require('../../apps-common/query-conf/step')({ defaultStep: 'revision' }),
+	{
+		name: 'processor',
+		ensure: function (value) {
+			if (!value) return;
+
+			return value;
+		}
+	}
+];

--- a/apps/statistics/get-query-conf.js
+++ b/apps/statistics/get-query-conf.js
@@ -2,10 +2,7 @@
 'use strict';
 
 var aFrom              = require('es5-ext/array/from')
-  , ensureArray        = require('es5-ext/array/valid-array')
-  , normalizeOptions   = require('es5-ext/object/normalize-options')
-
-  , stringify          = JSON.stringify;
+  , ensureArray        = require('es5-ext/array/valid-array');
 
 var queryConf = [
 	require('../../apps-common/query-conf/date-from'),
@@ -13,22 +10,11 @@ var queryConf = [
 ];
 
 module.exports = exports = function (data) {
-	var options = normalizeOptions(data)
-	  , processingStepsMeta = options.processingStepsMeta
-	  , conf = aFrom(queryConf);
+	var conf = aFrom(queryConf);
 
 	conf.push(
 		require('../../apps-common/query-conf/service'),
-		{
-			name: 'step',
-			ensure: function (value) {
-				if (!value) return;
-				if (!processingStepsMeta[value]) {
-					throw new Error("Unrecognized step value " + stringify(value));
-				}
-				return value;
-			}
-		}
+		require('../../apps-common/query-conf/step')()
 	);
 
 	if (exports.customQueryConf) {

--- a/routes/statistics.js
+++ b/routes/statistics.js
@@ -38,6 +38,9 @@ module.exports = {
 	'flow/by-role': {
 		view: require('../view/statistics-flow-roles')
 	},
+	'flow/by-operator': {
+		view: require('../view/statistics-flow-operators')
+	},
 
 	profile: require('../view/user-profile')
 };

--- a/server/routes/statistics.js
+++ b/server/routes/statistics.js
@@ -96,7 +96,7 @@ module.exports = function (config) {
 				dateRanges = getDateRangesByMode(query.dateFrom, query.dateTo, query.mode);
 				dateRanges.forEach(function (dateRange) {
 					// dateRange: { dateFrom: db.Date, dateTo: db.Date } with dateRange query for result
-					result[mode.getDisplayedKey(dateRange.dateFrom)] = null;
+					result[mode.getDisplayedKey(dateRange.dateFrom)] = {};
 				});
 
 				result = reduceOperators(assign({ data: result }, query));

--- a/server/routes/statistics.js
+++ b/server/routes/statistics.js
@@ -96,6 +96,7 @@ module.exports = function (config) {
 				dateRanges = getDateRangesByMode(query.dateFrom, query.dateTo, query.mode);
 				dateRanges.forEach(function (dateRange) {
 					// dateRange: { dateFrom: db.Date, dateTo: db.Date } with dateRange query for result
+					// TODO: add real data handler here
 					result[mode.getDisplayedKey(dateRange.dateFrom)] = {};
 				});
 

--- a/server/routes/statistics.js
+++ b/server/routes/statistics.js
@@ -99,7 +99,7 @@ module.exports = function (config) {
 					result[mode.getDisplayedKey(dateRange.dateFrom)] = {};
 				});
 
-				result = reduceOperators(assign({ data: result }, query));
+				result = reduceOperators(result, query);
 				Object.keys(result).forEach(function (date) {
 					Object.keys(result[date]).forEach(function (processorId) {
 						itemsCnt++;

--- a/test/utils/statistics-flow-reduce-operators.js
+++ b/test/utils/statistics-flow-reduce-operators.js
@@ -71,16 +71,12 @@ module.exports = function (t, a) {
 	expected = {
 		"2016-01-02": {
 			'7464567456': {
-				processor: '7464567456',
-				date: "2016-01-02",
 				approved: 13,
 				rejected: 0,
 				sentBack: 0,
 				processed: 13
 			},
 			'52345234': {
-				processor: '52345234',
-				date: "2016-01-02",
 				approved: 12,
 				rejected: 1,
 				sentBack: 0,
@@ -93,16 +89,12 @@ module.exports = function (t, a) {
 	expected = {
 		"2016-01-02": {
 			'7464567456': {
-				processor: '7464567456',
-				date: "2016-01-02",
 				approved: 2,
 				rejected: 0,
 				sentBack: 0,
 				processed: 2
 			},
 			'52345234': {
-				processor: '52345234',
-				date: "2016-01-02",
 				approved: 10,
 				rejected: 1,
 				sentBack: 0,
@@ -186,16 +178,12 @@ module.exports = function (t, a) {
 	expected = {
 		"2016-01-02": {
 			'7464567456': {
-				processor: '7464567456',
-				date: "2016-01-02",
 				approved: 16,
 				rejected: 1,
 				sentBack: 0,
 				processed: 17
 			},
 			'52345234': {
-				processor: '52345234',
-				date: "2016-01-02",
 				approved: 12,
 				rejected: 1,
 				sentBack: 0,

--- a/test/utils/statistics-flow-reduce-operators.js
+++ b/test/utils/statistics-flow-reduce-operators.js
@@ -1,0 +1,114 @@
+'use strict';
+
+module.exports = function (t, a) {
+	var expected, inputMap = {
+		"2016-01-02": {
+			serviceA: {
+				businessProcess: {
+					pending: 33,
+					sentBack: 40,
+					rejected: 2
+				},
+				certificate: {
+					certA: {
+						submitted: 20,
+						pending: 32
+					},
+					certB: {
+						submitted: 25,
+						pending: 14
+					}
+				},
+				processingStep: {
+					stepA: {
+						pending: {
+							businessProcess: 16,
+							certificate: {
+								certA: 5,
+								certB: 6
+							}
+						},
+						byProcessor: {
+							// processor id
+							'7464567456': {
+								approved: {
+									businessProcess: 13,
+									certificate: {
+										certA: 2,
+										certB: 4
+									}
+								},
+								rejected: {
+									businessProcess: 0,
+									certificate: {
+										certA: 0,
+										certB: 0
+									}
+								}
+							},
+							'52345234': {
+								approved: {
+									businessProcess: 12,
+									certificate: {
+										certA: 10,
+										certB: 2
+									}
+								},
+								rejected: {
+									businessProcess: 1,
+									certificate: {
+										certA: 1,
+										certB: 0
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	};
+	expected = {
+		"2016-01-02": {
+			'7464567456': {
+				processor: '7464567456',
+				date: "2016-01-02",
+				approved: 13,
+				rejected: 0,
+				sentBack: 0,
+				processed: 13
+			},
+			'52345234': {
+				processor: '52345234',
+				date: "2016-01-02",
+				approved: 12,
+				rejected: 1,
+				sentBack: 0,
+				processed: 13
+			}
+		}
+	};
+	a.deep(t({ data: inputMap, step: 'stepA' }), expected);
+	// certificate
+	expected = {
+		"2016-01-02": {
+			'7464567456': {
+				processor: '7464567456',
+				date: "2016-01-02",
+				approved: 2,
+				rejected: 0,
+				sentBack: 0,
+				processed: 2
+			},
+			'52345234': {
+				processor: '52345234',
+				date: "2016-01-02",
+				approved: 10,
+				rejected: 1,
+				sentBack: 0,
+				processed: 11
+			}
+		}
+	};
+	a.deep(t({ data: inputMap, step: 'stepA', certificate: 'certA' }), expected);
+};

--- a/test/utils/statistics-flow-reduce-operators.js
+++ b/test/utils/statistics-flow-reduce-operators.js
@@ -88,7 +88,7 @@ module.exports = function (t, a) {
 			}
 		}
 	};
-	a.deep(t({ data: inputMap, step: 'stepA' }), expected);
+	a.deep(t(inputMap, { step: 'stepA' }), expected);
 	// certificate
 	expected = {
 		"2016-01-02": {
@@ -110,5 +110,5 @@ module.exports = function (t, a) {
 			}
 		}
 	};
-	a.deep(t({ data: inputMap, step: 'stepA', certificate: 'certA' }), expected);
+	a.deep(t(inputMap, { step: 'stepA', certificate: 'certA' }), expected);
 };

--- a/test/utils/statistics-flow-reduce-operators.js
+++ b/test/utils/statistics-flow-reduce-operators.js
@@ -193,4 +193,6 @@ module.exports = function (t, a) {
 	};
 
 	a.deep(t(inputMap, { step: 'stepA' }), expected);
+	//non existing step
+	a.deep(t(inputMap, { step: 'stepB' }), { "2016-01-02": {} });
 };

--- a/test/utils/statistics-flow-reduce-operators.js
+++ b/test/utils/statistics-flow-reduce-operators.js
@@ -111,4 +111,98 @@ module.exports = function (t, a) {
 		}
 	};
 	a.deep(t(inputMap, { step: 'stepA', certificate: 'certA' }), expected);
+
+	inputMap = {
+		"2016-01-02": {
+			serviceA: {
+				processingStep: {
+					stepA: {
+						byProcessor: {
+							// processor id
+							'7464567456': {
+								approved: {
+									businessProcess: 13,
+									certificate: {
+										certA: 2,
+										certB: 4
+									}
+								},
+								rejected: {
+									businessProcess: 0,
+									certificate: {
+										certA: 0,
+										certB: 0
+									}
+								}
+							},
+							'52345234': {
+								approved: {
+									businessProcess: 12,
+									certificate: {
+										certA: 10,
+										certB: 2
+									}
+								},
+								rejected: {
+									businessProcess: 1,
+									certificate: {
+										certA: 1,
+										certB: 0
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			serviceB: {
+				processingStep: {
+					stepA: {
+						byProcessor: {
+							// processor id
+							'7464567456': {
+								approved: {
+									businessProcess: 3,
+									certificate: {
+										certA: 3,
+										certB: 5
+									}
+								},
+								rejected: {
+									businessProcess: 1,
+									certificate: {
+										certA: 1,
+										certB: 0
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	};
+
+	expected = {
+		"2016-01-02": {
+			'7464567456': {
+				processor: '7464567456',
+				date: "2016-01-02",
+				approved: 16,
+				rejected: 1,
+				sentBack: 0,
+				processed: 17
+			},
+			'52345234': {
+				processor: '52345234',
+				date: "2016-01-02",
+				approved: 12,
+				rejected: 1,
+				sentBack: 0,
+				processed: 13
+			}
+		}
+	};
+
+	a.deep(t(inputMap, { step: 'stepA' }), expected);
 };

--- a/utils/statistics-flow-reduce-operators.js
+++ b/utils/statistics-flow-reduce-operators.js
@@ -12,8 +12,6 @@
  *
  * TO:
  * [date][processorId] = {
- *  processor: processorId,
- *  date: "YYYY-MM-DD",
  *  approved: num,
  *  rejected: num,
  *  sentBack: num,
@@ -33,8 +31,6 @@ var isEmptyResult = function (processorRow) {
 
 var buildResultByProcessor = function (row, currentRow, certificate, processorId, date) {
 	var result = currentRow || {
-		date: date,
-		processor: processorId,
 		processed: 0,
 		approved: 0,
 		sentBack: 0,

--- a/utils/statistics-flow-reduce-operators.js
+++ b/utils/statistics-flow-reduce-operators.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var isEmptyResult = function (processorRow) {
+	if (!processorRow) return true;
+	return !processorRow.approved && !processorRow.rejected &&
+		!processorRow.sentBack;
+};
+
+var buildResultByProcessor = function (row, certificate, processorId, date) {
+	var result = {
+		date: date,
+		processor: processorId,
+		processed: 0,
+		approved: 0,
+		sentBack: 0,
+		rejected: 0
+	};
+	['approved', 'sentBack', 'rejected'].forEach(function (status) {
+		if (!row[status]) return;
+		if (!result[status]) {
+			result[status] = 0;
+		}
+		if (!result.processed) {
+			result.processed = 0;
+		}
+		if (certificate) {
+			if (!row[status].certificate[certificate]) return;
+			result[status] += row[status].certificate[certificate];
+			result.processed += row[status].certificate[certificate];
+		} else {
+			result[status] += row[status].businessProcess;
+			result.processed += row[status].businessProcess;
+		}
+	});
+
+	return result;
+};
+
+module.exports = function (params) {
+	var data, service, step, processor, certificate, finalResult, reducedRows, processorRow;
+	data      = params.data;
+	service   = params.service;
+	step      = params.step;
+	processor = params.processor;
+	certificate = params.certificate;
+	finalResult = {};
+
+	Object.keys(data).forEach(function (date) {
+		reducedRows = [data[date]];
+		finalResult[date] = {};
+
+		if (service) {
+			reducedRows = reducedRows.map(function (reducedRow) {
+				return reducedRow[service];
+			});
+		} else {
+			reducedRows = Object.keys(reducedRows[0]).map(function (serviceName) {
+				return reducedRows[0][serviceName];
+			});
+		}
+		reducedRows = reducedRows.map(function (row) {
+			return row.processingStep[step].byProcessor;
+		});
+
+		reducedRows.forEach(function (reducedRow) {
+			if (processor) {
+				processorRow = reducedRow[processor];
+				if (isEmptyResult(processorRow)) return;
+				finalResult[date][processor] =
+					buildResultByProcessor(processorRow, certificate, processor, date);
+			} else {
+				Object.keys(reducedRow).forEach(function (processorId) {
+					processorRow = reducedRow[processorId];
+					if (isEmptyResult(processorRow)) return;
+					finalResult[date][processorId] =
+						buildResultByProcessor(processorRow, certificate, processorId, date);
+				});
+			}
+		});
+	});
+
+	return finalResult;
+};

--- a/utils/statistics-flow-reduce-operators.js
+++ b/utils/statistics-flow-reduce-operators.js
@@ -1,5 +1,32 @@
 'use strict';
 
+/**
+ * It's about reduction
+ *
+ * FROM:
+ *
+ * [date][serviceName].businessProcess[status] = num;
+ * [date][serviceName].certificate[name][status] = num;
+ * [date][serviceName].processingStep[stepName].pending.businessProcess = num;
+ * [date][serviceName].processingStep[stepName].pending.certificate[name] = num;
+ * [date][serviceName].processingStep[stepName].byProcessor[processorId][status].businessProcess =
+ * num;
+ * [date][serviceName].processingStep[stepName].byProcessor[processorId][status].certificate[name] =
+ * num;
+ *
+ * TO:
+ * [date][processorId] = {
+ *  processor: processorId,
+ *  date: "YYYY-MM-DD",
+ *  approved: num,
+ *  rejected: num,
+ *  sentBack: num,
+ *  processed: num
+ *  }
+ *
+ * @type {Object.keys|*}
+ */
+
 var isEmptyResult = function (processorRow) {
 	if (!processorRow) return true;
 	return !processorRow.approved && !processorRow.rejected &&
@@ -36,13 +63,12 @@ var buildResultByProcessor = function (row, certificate, processorId, date) {
 	return result;
 };
 
-module.exports = function (params) {
-	var data, service, step, processor, certificate, finalResult, reducedRows, processorRow;
-	data      = params.data;
-	service   = params.service;
-	step      = params.step;
-	processor = params.processor;
-	certificate = params.certificate;
+module.exports = function (data, query) {
+	var service, step, processor, certificate, finalResult, reducedRows, processorRow;
+	service     = query.service;
+	step        = query.step;
+	processor   = query.processor;
+	certificate = query.certificate;
 	finalResult = {};
 
 	Object.keys(data).forEach(function (date) {

--- a/utils/statistics-flow-reduce-operators.js
+++ b/utils/statistics-flow-reduce-operators.js
@@ -24,7 +24,6 @@
  *  processed: num
  *  }
  *
- * @type {Object.keys|*}
  */
 
 var isEmptyResult = function (processorRow) {

--- a/utils/statistics-flow-reduce-operators.js
+++ b/utils/statistics-flow-reduce-operators.js
@@ -71,8 +71,9 @@ module.exports = function (data, query) {
 		reducedRows = service ? [data[date][service]] : toArray(data[date], identity);
 
 		reducedRows = reducedRows.map(function (row) {
+			if (!row.processingStep[step]) return;
 			return row.processingStep[step].byProcessor;
-		});
+		}).filter(Boolean);
 
 		reducedRows.forEach(function (reducedRow) {
 			if (processor) {

--- a/view/components/filter-bar/select-user.js
+++ b/view/components/filter-bar/select-user.js
@@ -1,8 +1,13 @@
 'use strict';
 
-var _            = require('mano').i18n.bind('View: Select User')
-  , db           = require('../../../db')
-  , location     = require('mano/lib/client/location');
+/**
+ * Provides a select view component, which lists given collection of users (all users by default).
+ * The select adds it's selected options value into url query.
+ */
+
+var _        = require('mano').i18n.bind('View: Select User')
+  , db       = require('../../../db')
+  , location = require('mano/lib/client/location');
 
 module.exports = function (/* opts */) {
 	var opts, name, label, id, userQuery, usersCollection;

--- a/view/components/filter-bar/select-user.js
+++ b/view/components/filter-bar/select-user.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var _            = require('mano').i18n.bind('View: Select User')
+  , db           = require('../../../db')
+  , location     = require('mano/lib/client/location');
+
+module.exports = function (/* opts */) {
+	var opts, name, label, id, userQuery, usersCollection;
+	opts         = Object(arguments[0]);
+	name         = opts.name || 'user';
+	label        = opts.label || _("All");
+	id           = opts.id || 'user-select';
+	usersCollection = opts.usersCollection || db.User.instances;
+	userQuery = location.query.get(name);
+	return select(
+		{ id: id, name: name },
+		option({ value: '', selected: userQuery.map(function (value) {
+			return value ? null : 'selected';
+		}) }, label),
+		list(usersCollection, function (user) {
+			return option({
+				value: user.__id__,
+				selected: userQuery.map(function (value) {
+					var selected = (user.__id__ ? (value === user.__id__) : (value == null));
+					return selected ? 'selected' : null;
+				})
+			}, user.fullName);
+		})
+	);
+};

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -4,22 +4,18 @@ var _                 = require('mano').i18n.bind('View: Statistics')
   , db                = require('../db')
   , uncapitalize      = require('es5-ext/string/#/uncapitalize')
   , location          = require('mano/lib/client/location')
-  , queryHandlerConf  = require('../apps/statistics/flow-query-conf')
+  , queryHandlerConf  = require('../apps/statistics/flow-query-operators-conf')
   , setupQueryHandler = require('../utils/setup-client-query-handler')
   , copy              = require('es5-ext/object/copy')
   , ObservableValue   = require('observable-value')
-  , assign            = require('es5-ext/object/assign')
   , Pagination        = require('./components/pagination')
   , modes             = require('../utils/statistics-flow-group-modes')
   , selectService     = require('./components/filter-bar/select-service')
   , selectCertificate = require('./components/filter-bar/select-certificate')
   , selectPeriodMode  = require('./components/filter-bar/select-period-mode')
   , selectUser        = require('./components/filter-bar/select-user')
-  , serviceQuery      = require('../apps-common/query-conf/service')
-  , certificateQuery  = require('../apps-common/query-conf/certificate')
-  , pageQuery         = require('../utils/query/date-constrained-page')
   , processingSteps   = require('../processing-steps-meta')
-  , queryServer       = require('./utils/statistics-flow-query-server')
+  , queryServer       = require('./utils/statistics-flow-operators-query-server')
   , getStepLabelByShortPath = require('../utils/get-step-label-by-short-path')
   , isOfficialRoleName      = require('../utils/is-official-role-name')
   , usersCollection         = db.User.instances.filterByKey('roles', function (roles) {
@@ -50,86 +46,9 @@ db.BusinessProcess.extensions.forEach(function (ServiceType) {
 	});
 });
 
-var buildResultByProcessor = function (finalResult, row, processorId, certificate) {
-	if (!finalResult[processorId]) {
-		finalResult[processorId] = {};
-	}
-	['approved', 'sentBack', 'rejected'].forEach(function (status) {
-		if (!row[status]) return;
-		if (!finalResult[processorId][status]) {
-			finalResult[processorId][status] = 0;
-		}
-		if (!finalResult[processorId].processed) {
-			finalResult[processorId].processed = 0;
-		}
-		if (certificate) {
-			if (!row[status].certificate[certificate]) return;
-			finalResult[processorId][status] += row[status].certificate[certificate];
-			finalResult[processorId].processed += row[status].certificate[certificate];
-		} else {
-			finalResult[processorId][status] += row[status].businessProcess;
-			finalResult[processorId].processed += row[status].businessProcess;
-		}
-	});
-};
-
-var buildFilteredResult = function (data, date, service, certificate, step, processor) {
-	var finalResult = {}, reducedRows = [data], row;
-
-	if (service) {
-		reducedRows = reducedRows.map(function (reducedRow) {
-			return reducedRow[service];
-		});
-	} else {
-		reducedRows = Object.keys(reducedRows[0]).map(function (serviceName) {
-			return reducedRows[0][serviceName];
-		});
-	}
-	reducedRows = reducedRows.map(function (row) {
-		return row.processingStep[step].byProcessor;
-	});
-
-	reducedRows.forEach(function (reducedRow) {
-		if (processor) {
-			row = reducedRow[processor];
-			if (!row) {
-				finalResult[processor] = {};
-				return;
-			}
-			buildResultByProcessor(finalResult, row, processor, certificate);
-		} else {
-			Object.keys(reducedRow).forEach(function (processorId) {
-				row = reducedRow[processorId];
-				buildResultByProcessor(finalResult, row, processorId, certificate);
-			});
-		}
-	});
-
-	return Object.keys(finalResult).map(function (processorId) {
-		return assign({
-			date: date,
-			processor: null,
-			processed: 0,
-			approved: 0,
-			sentBack: 0,
-			rejected: 0
-		}, { processor: processorId }, finalResult[processorId]);
-	});
-};
-
-var filterData = function (data, query) {
-	var result = [];
-	Object.keys(data).forEach(function (date) {
-		Array.prototype.push.apply(result, buildFilteredResult(data[date], date,
-			query.service, query.certificate, query.step, query.processor));
-	});
-
-	return result;
-};
-
 exports['statistics-main'] = function () {
 	var queryHandler, tables = new ObservableValue({})
-	  , pagination = new Pagination('/flow/'), handlerConf, tablesValue = {};
+	  , pagination = new Pagination('/flow/by-operator/'), tablesValue = {};
 
 	Object.keys(processingSteps).forEach(function (stepShortPath) {
 		tablesValue[stepShortPath] = new ObservableValue({});
@@ -137,20 +56,7 @@ exports['statistics-main'] = function () {
 
 	tables.value = tablesValue;
 
-	handlerConf = queryHandlerConf.slice(0);
-	handlerConf.push(pageQuery, serviceQuery, certificateQuery, {
-		name: 'processor',
-		ensure: function (value) {
-			if (!value) return;
-
-			if (!usersCollection.getById(value)) {
-				throw new Error("Unrecognized processor value " + JSON.stringify(value));
-			}
-
-			return value;
-		}
-	});
-	queryHandler = setupQueryHandler(handlerConf,
+	queryHandler = setupQueryHandler(queryHandlerConf,
 		location, '/flow/by-operator/');
 
 	queryHandler.on('query', function (query) {
@@ -161,21 +67,10 @@ exports['statistics-main'] = function () {
 
 		serverQuery.dateFrom = dateFrom.toJSON();
 		serverQuery.dateTo = dateTo.toJSON();
-
-		delete serverQuery.service;
-		delete serverQuery.certificate;
-		delete serverQuery.pageCount;
+		// hard code for tests
 
 		queryServer(serverQuery).done(function (responseData) {
-			if (query.step) {
-				tables.value[query.step].value = filterData(responseData,
-					assign(query, { dateFrom: dateFrom, dateTo: dateTo }));
-			} else {
-				Object.keys(tables.value).forEach(function (stepShortPath) {
-					tables.value[stepShortPath].value = filterData(responseData,
-						assign({ step: stepShortPath }, query, { dateFrom: dateFrom, dateTo: dateTo }));
-				});
-			}
+			tables.value[query.step].value = responseData;
 
 			pagination.count.value   = query.pageCount;
 			pagination.current.value = query.page;
@@ -217,7 +112,7 @@ exports['statistics-main'] = function () {
 	section({ class: "section-primary" },
 		list(Object.keys(tables.value), function (key) {
 			return tables.value[key].map(function (result) {
-				if (!result || !result.length) return;
+				if (!result || !Object.keys(result).length) return;
 				var mode = modes.get(location.query.mode || 'daily');
 				return section({ class: "section-primary" },
 					h3(getStepLabelByShortPath(key)),
@@ -231,13 +126,13 @@ exports['statistics-main'] = function () {
 							th({ class: 'statistics-table-number' }, _("Rejected"))
 						),
 						tbody({ onEmpty: tr(td({ class: 'empty', colspan: 6 },
-							_("No data for this criteria"))) }, result, function (resultRow) {
-							return tr(
-								list(Object.keys(resultRow), function (prop) {
-									return td({ class: 'statistics-table-number' }, resultRow[prop]);
-								})
-							);
-						})));
+							_("No data for this criteria"))) }, Object.keys(result).map(function (date) {
+							return Object.keys(result[date]).map(function (processorId) {
+								return tr(list(Object.keys(result[date][processorId]), function (prop) {
+									return td({ class: 'statistics-table-number' }, result[date][processorId][prop]);
+								}));
+							});
+						}))));
 			});
 		}));
 };

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -1,0 +1,233 @@
+'use strict';
+
+var _                 = require('mano').i18n.bind('View: Statistics')
+  , db                = require('../db')
+  , uncapitalize      = require('es5-ext/string/#/uncapitalize')
+  , location          = require('mano/lib/client/location')
+  , queryHandlerConf  = require('../apps/statistics/flow-query-conf')
+  , setupQueryHandler = require('../utils/setup-client-query-handler')
+  , copy              = require('es5-ext/object/copy')
+  , ObservableValue   = require('observable-value')
+  , assign            = require('es5-ext/object/assign')
+  , Pagination        = require('./components/pagination')
+  , modes             = require('../utils/statistics-flow-group-modes')
+  , selectService     = require('./components/filter-bar/select-service')
+  , selectCertificate = require('./components/filter-bar/select-certificate')
+  , selectPeriodMode  = require('./components/filter-bar/select-period-mode')
+  , itemsPerPage      = require('../conf/objects-list-items-per-page')
+  , serviceQuery      = require('../apps-common/query-conf/service')
+  , certificateQuery  = require('../apps-common/query-conf/certificate')
+  , pageQuery         = require('../utils/query/date-constrained-page')
+  , copyDbDate        = require('../utils/copy-db-date')
+  , queryServer       = require('./utils/statistics-flow-query-server')
+  , incrementDateByTimeUnit = require('../utils/increment-date-by-time-unit')
+  , floorToTimeUnit         = require('../utils/floor-to-time-unit')
+  , calculateDurationByMode = require('../utils/calculate-duration-by-mode');
+
+exports._parent        = require('./statistics-flow');
+exports._customFilters = Function.prototype;
+
+exports['flow-nav']                = { class: { 'submitted-menu-item-active': true } };
+exports['flow-by-operator-nav'] = { class: { 'pills-nav-active': true } };
+
+var serviceToCertLegacyMatch = { '': [] };
+
+var getServiceName = function (ServiceType) {
+	return uncapitalize.call(
+		ServiceType.__id__.slice('BusinessProcess'.length)
+	);
+};
+
+db.BusinessProcess.extensions.forEach(function (ServiceType) {
+	ServiceType.prototype.certificates.map.forEach(function (certificate) {
+		if (!serviceToCertLegacyMatch[getServiceName(ServiceType)]) {
+			serviceToCertLegacyMatch[getServiceName(ServiceType)] = [];
+		}
+		serviceToCertLegacyMatch[getServiceName(ServiceType)].push('certificate-' + certificate.key);
+		serviceToCertLegacyMatch[''].push('certificate-' + certificate.key);
+	});
+});
+
+var buildResultRow = function (rowData) {
+	return assign({
+		submitted: 0,
+		pending: 0,
+		pickup: 0,
+		withdrawn: 0,
+		rejected: 0,
+		sentBack: 0
+	}, rowData || {});
+};
+
+var accumulateResultRows = function (rows) {
+	var result = buildResultRow(rows[0]);
+	rows.slice(1).forEach(function (row) {
+		Object.keys(row).forEach(function (propertyName) {
+			result[propertyName] += row[propertyName];
+		});
+	});
+
+	return result;
+};
+
+var buildFilteredResult = function (data, key, service, certificate) {
+	if (!data[key]) return buildResultRow();
+	if (service && certificate) {
+		return buildResultRow(data[key][service].certificate[certificate]);
+	}
+	if (service) {
+		return buildResultRow(data[key][service].businessProcess);
+	}
+	var rowsToAccumulate = [];
+	Object.keys(data[key]).forEach(function (service) {
+		if (certificate) {
+			if (!data[key][service].certificate[certificate]) return;
+			rowsToAccumulate.push(data[key][service].certificate[certificate]);
+		} else {
+			rowsToAccumulate.push(data[key][service].businessProcess);
+		}
+	});
+	return accumulateResultRows(rowsToAccumulate);
+};
+
+var filterData = function (data, query) {
+	var result = {};
+
+	Object.keys(data).forEach(function (date) {
+		result[date] = buildFilteredResult(data, date, query.service, query.certificate);
+	});
+
+	return result;
+};
+
+exports['statistics-main'] = function () {
+	var queryHandler, tables = new ObservableValue({})
+	  , pagination = new Pagination('/flow/'), handlerConf;
+
+	tables.value = {
+		revision: new ObservableValue({}),
+		precal: new ObservableValue({})
+	};
+
+	handlerConf = queryHandlerConf.slice(0);
+	handlerConf.push(pageQuery, serviceQuery, certificateQuery);
+	queryHandler = setupQueryHandler(handlerConf,
+		location, '/flow/by-operator/');
+
+	queryHandler.on('query', function (query) {
+		var serverQuery = copy(query), dateFrom, dateTo, mode
+		  , currentDate, offset, timeUnitsCount = 0, durationInTimeUnits, page;
+
+		dateFrom = query.dateFrom;
+		dateTo   = query.dateTo || new db.Date();
+		mode     = query.mode;
+		page     = query.page;
+
+		durationInTimeUnits = calculateDurationByMode(dateFrom, dateTo, mode);
+		if (query.pageCount > 1) {
+			offset = { from: ((page - 1) * itemsPerPage) };
+			offset.to = offset.from;
+			if ((durationInTimeUnits - offset.from) < itemsPerPage) {
+				offset.to += durationInTimeUnits - offset.from;
+			} else {
+				offset.to += itemsPerPage;
+			}
+			offset.to -= 1;
+
+			currentDate = copyDbDate(dateFrom);
+			floorToTimeUnit(currentDate, mode);
+			while (timeUnitsCount <= offset.to) {
+				if (timeUnitsCount === offset.from && query.page > 1) {
+					dateFrom = copyDbDate(currentDate);
+				}
+				if (timeUnitsCount === offset.to && query.page < query.pageCount) {
+					dateTo = incrementDateByTimeUnit(copyDbDate(currentDate), mode);
+					dateTo.setUTCDate(dateTo.getUTCDate() - 1);
+				}
+				timeUnitsCount++;
+				incrementDateByTimeUnit(currentDate, mode);
+			}
+		}
+		serverQuery.dateFrom = dateFrom.toJSON();
+		serverQuery.dateTo = dateTo.toJSON();
+
+		delete serverQuery.service;
+		delete serverQuery.page;
+		delete serverQuery.certificate;
+		delete serverQuery.pageCount;
+
+		queryServer(serverQuery).done(function (responseData) {
+			var filteredData = filterData(responseData,
+				assign(query, { dateFrom: dateFrom, dateTo: dateTo }));
+			tables.value.revision.value = filteredData;
+			tables.value.precal.value = filteredData;
+			pagination.count.value   = query.pageCount;
+			pagination.current.value = query.page;
+		});
+	});
+
+	section({ class: 'section-primary users-table-filter-bar' },
+		form({ action: '/flow/by-operator/', autoSubmit: true },
+			div({ class: 'users-table-filter-bar-status' },
+				selectService({ label: _("All services") })),
+			div({ class: 'users-table-filter-bar-status' },
+				selectCertificate(),
+				legacy('selectMatch', 'service-select', serviceToCertLegacyMatch)),
+			div(
+				{ class: 'users-table-filter-bar-status' },
+				label({ for: 'date-from-input' }, _("Date from"), ":"),
+				input({ id: 'date-from-input', type: 'date',
+					name: 'dateFrom', value: location.query.get('dateFrom').map(function (dateFrom) {
+					var now = new db.Date();
+					now.setDate(now.getDate() - 7);
+					return dateFrom || now.toISOString().slice(0, 10);
+				}) })
+			),
+			div(
+				{ class: 'users-table-filter-bar-status' },
+				label({ for: 'date-to-input' }, _("Date to"), ":"),
+				input({ id: 'date-to-input', type: 'date',
+					name: 'dateTo', value: location.query.get('dateTo') })
+			),
+			selectPeriodMode(),
+			p({ class: 'submit' }, input({ type: 'submit' }))));
+
+	section(pagination);
+	section({ class: "section-primary" },
+		list(Object.keys(tables.value), function (key) {
+			return tables.value[key].map(function (result) {
+				if (!result) return;
+				return section({ class: "section-primary" },
+					h3(key),
+					table({ class: 'statistics-table' },
+						thead(
+							th({ class: 'statistics-table-number' },
+								location.query.get("mode").map(function (mode) {
+									var title;
+									if (!mode) return;
+									modes.some(function (m) {
+										if (mode === m.key) {
+											title = m.labelNoun;
+											return true;
+										}
+									});
+									return title;
+								})),
+							th({ class: 'statistics-table-number' }, _("Operator")),
+							th({ class: 'statistics-table-number' }, _("Files Processed")),
+							th({ class: 'statistics-table-number' }, _("Validated")),
+							th({ class: 'statistics-table-number' }, _("Sent Back for corrections")),
+							th({ class: 'statistics-table-number' }, _("Rejected"))
+						),
+						tbody({ onEmpty: tr(td({ class: 'empty', colspan: 6 },
+							_("No data for this criteria"))) }, Object.keys(result), function (key) {
+							return tr(
+								td(key),
+								list(Object.keys(result[key]), function (status) {
+									return td({ class: 'statistics-table-number' }, result[key][status]);
+								})
+							);
+						})));
+			});
+		}));
+};

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -70,10 +70,10 @@ exports['statistics-main'] = function () {
 		// hard code for tests
 
 		queryServer(serverQuery).done(function (responseData) {
-			tables.value[query.step].value = responseData;
+			tables.value[query.step].value = responseData.data;
 
-			pagination.count.value   = query.pageCount;
-			pagination.current.value = query.page;
+			pagination.current.value = Number(serverQuery.page);
+			pagination.count.value   = responseData.pageCount;
 		});
 	});
 
@@ -112,7 +112,6 @@ exports['statistics-main'] = function () {
 	section({ class: "section-primary" },
 		list(Object.keys(tables.value), function (key) {
 			return tables.value[key].map(function (result) {
-				if (!result || !Object.keys(result).length) return;
 				var mode = modes.get(location.query.mode || 'daily');
 				return section({ class: "section-primary" },
 					h3(getStepLabelByShortPath(key)),
@@ -125,8 +124,11 @@ exports['statistics-main'] = function () {
 							th({ class: 'statistics-table-number' }, _("Sent Back for corrections")),
 							th({ class: 'statistics-table-number' }, _("Rejected"))
 						),
-						tbody({ onEmpty: tr(td({ class: 'empty', colspan: 6 },
-							_("No data for this criteria"))) }, Object.keys(result).map(function (date) {
+						tbody(Object.keys(result).map(function (date) {
+							if (!Object.keys(result[date]).length) {
+								return tr(td({ class: 'empty statistics-table-info', colspan: 6 },
+									_("No data for this criteria")));
+							}
 							return Object.keys(result[date]).map(function (processorId) {
 								return tr(list(Object.keys(result[date][processorId]), function (prop) {
 									return td({ class: 'statistics-table-number' }, result[date][processorId][prop]);

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -17,11 +17,7 @@ var _                 = require('mano').i18n.bind('View: Statistics')
   , processingSteps   = require('../processing-steps-meta')
   , queryServer       = require('./utils/statistics-flow-operators-query-server')
   , oToArray           = require('es5-ext/object/to-array')
-  , getStepLabelByShortPath = require('../utils/get-step-label-by-short-path')
-  , isOfficialRoleName      = require('../utils/is-official-role-name')
-  , usersCollection         = db.User.instances.filterByKey('roles', function (roles) {
-	return roles.some(isOfficialRoleName);
-});
+  , getStepLabelByShortPath = require('../utils/get-step-label-by-short-path');
 
 exports._parent        = require('./statistics-flow');
 exports._customFilters = Function.prototype;
@@ -80,8 +76,7 @@ exports['statistics-main'] = function () {
 				selectCertificate(),
 				legacy('selectMatch', 'service-select', serviceToCertLegacyMatch)),
 			div({ class: 'users-table-filter-bar-status' },
-				selectUser({ label: _("All operators"), name: 'processor',
-					usersCollection: usersCollection })),
+				selectUser({ label: _("All operators"), name: 'processor' })),
 			div(
 				{ class: 'users-table-filter-bar-status' },
 				label({ for: 'date-from-input' }, _("Date from"), ":"),

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -105,14 +105,28 @@ exports['statistics-main'] = function () {
 				input({ id: 'date-to-input', type: 'date',
 					name: 'dateTo', value: location.query.get('dateTo') })
 			),
+			select(
+				{ id: 'select-step', name: 'step' },
+				list(Object.keys(processingSteps), function (step) {
+					return option({
+						value: step,
+						selected: location.query.get('step').map(function (value) {
+							var selected = (step ? (value === step) : (value == null));
+							return selected ? 'selected' : null;
+						})
+					}, getStepLabelByShortPath(step));
+				})
+			),
 			selectPeriodMode(),
 			p({ class: 'submit' }, input({ type: 'submit' }))));
 
 	section(pagination);
 	section({ class: "section-primary" },
-		list(Object.keys(tables.value), function (key) {
+		location.query.get('step').map(function (key) {
+			var mode = modes.get(location.query.mode || 'daily');
+			if (!key) key = Object.keys(processingSteps)[0];
 			return tables.value[key].map(function (result) {
-				var mode = modes.get(location.query.mode || 'daily');
+
 				return section({ class: "section-primary" },
 					h3(getStepLabelByShortPath(key)),
 					table({ class: 'statistics-table' },
@@ -131,7 +145,14 @@ exports['statistics-main'] = function () {
 							}
 							return Object.keys(result[date]).map(function (processorId) {
 								return tr(list(Object.keys(result[date][processorId]), function (prop) {
-									return td({ class: 'statistics-table-number' }, result[date][processorId][prop]);
+									var display;
+									if (prop === 'processor') {
+										display = db.User.getById(processorId) || _('Unknown user');
+									} else {
+										display = result[date][processorId][prop];
+									}
+
+									return td({ class: 'statistics-table-number' }, display);
 								}));
 							});
 						}))));

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -178,9 +178,11 @@ exports['statistics-main'] = function () {
 				label({ for: 'date-from-input' }, _("Date from"), ":"),
 				input({ id: 'date-from-input', type: 'date',
 					name: 'dateFrom', value: location.query.get('dateFrom').map(function (dateFrom) {
-					var now = new db.Date();
-					now.setDate(now.getDate() - 7);
-					return dateFrom || now.toISOString().slice(0, 10);
+					var now = new db.Date(), defaultDate;
+					defaultDate = new db.Date(now.getUTCFullYear(), now.getUTCMonth(),
+								now.getUTCDate() - 6);
+
+					return dateFrom || defaultDate;
 				}) })
 			),
 			div(
@@ -197,22 +199,12 @@ exports['statistics-main'] = function () {
 		list(Object.keys(tables.value), function (key) {
 			return tables.value[key].map(function (result) {
 				if (!result) return;
+				var mode = modes.get(location.query.mode || 'daily');
 				return section({ class: "section-primary" },
 					h3(key),
 					table({ class: 'statistics-table' },
 						thead(
-							th({ class: 'statistics-table-number' },
-								location.query.get("mode").map(function (mode) {
-									var title;
-									if (!mode) return;
-									modes.some(function (m) {
-										if (mode === m.key) {
-											title = m.labelNoun;
-											return true;
-										}
-									});
-									return title;
-								})),
+							th({ class: 'statistics-table-number' }, mode.labelNoun),
 							th({ class: 'statistics-table-number' }, _("Operator")),
 							th({ class: 'statistics-table-number' }, _("Files Processed")),
 							th({ class: 'statistics-table-number' }, _("Validated")),

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -14,6 +14,8 @@ var _                 = require('mano').i18n.bind('View: Statistics')
   , selectCertificate = require('./components/filter-bar/select-certificate')
   , selectPeriodMode  = require('./components/filter-bar/select-period-mode')
   , selectUser        = require('./components/filter-bar/select-user')
+  , selectDateFrom    = require('./components/filter-bar/select-date-from')
+  , selectDateTo      = require('./components/filter-bar/select-date-to')
   , processingSteps   = require('../processing-steps-meta')
   , queryServer       = require('./utils/statistics-flow-operators-query-server')
   , oToArray           = require('es5-ext/object/to-array')
@@ -80,20 +82,12 @@ exports['statistics-main'] = function () {
 			div(
 				{ class: 'users-table-filter-bar-status' },
 				label({ for: 'date-from-input' }, _("Date from"), ":"),
-				input({ id: 'date-from-input', type: 'date',
-					name: 'dateFrom', value: location.query.get('dateFrom').map(function (dateFrom) {
-					var now = new db.Date(), defaultDate;
-					defaultDate = new db.Date(now.getUTCFullYear(), now.getUTCMonth(),
-								now.getUTCDate() - 6);
-
-					return dateFrom || defaultDate;
-				}) })
+				selectDateFrom()
 			),
 			div(
 				{ class: 'users-table-filter-bar-status' },
 				label({ for: 'date-to-input' }, _("Date to"), ":"),
-				input({ id: 'date-to-input', type: 'date',
-					name: 'dateTo', value: location.query.get('dateTo') })
+				selectDateTo()
 			),
 			div({ class: 'users-table-filter-bar-status' },
 				select(

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -64,7 +64,6 @@ exports['statistics-main'] = function () {
 		// hard code for tests
 
 		queryServer(serverQuery).done(function (responseData) {
-			console.log('responseData.data...................', responseData.data);
 			data.value = responseData.data;
 
 			pagination.current.value = Number(serverQuery.page);

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -16,6 +16,7 @@ var _                 = require('mano').i18n.bind('View: Statistics')
   , selectUser        = require('./components/filter-bar/select-user')
   , processingSteps   = require('../processing-steps-meta')
   , queryServer       = require('./utils/statistics-flow-operators-query-server')
+  , oToArray           = require('es5-ext/object/to-array')
   , getStepLabelByShortPath = require('../utils/get-step-label-by-short-path')
   , isOfficialRoleName      = require('../utils/is-official-role-name')
   , usersCollection         = db.User.instances.filterByKey('roles', function (roles) {
@@ -132,20 +133,19 @@ exports['statistics-main'] = function () {
 						th({ class: 'statistics-table-number' }, _("Sent Back for corrections")),
 						th({ class: 'statistics-table-number' }, _("Rejected"))
 					),
-					tbody(Object.keys(result).length ? Object.keys(result).map(function (date) {
-						return Object.keys(result[date]).map(function (processorId) {
-							return tr(list(Object.keys(result[date][processorId]), function (prop) {
-								var display;
-								if (prop === 'processor') {
-									display = db.User.getById(processorId) || _('Unknown user');
-								} else {
-									display = result[date][processorId][prop];
-								}
-
-								return td({ class: 'statistics-table-number' }, display);
-							}));
-						});
-					}) : tr(td({ class: 'empty statistics-table-info', colspan: 6 },
+					tbody(Object.keys(result).length ?
+							oToArray(result, function (dateResult, date) {
+								return oToArray(dateResult, function (processorResult, processorId) {
+									return tr(
+										td({ class: 'statistics-table-number' }, date),
+										td({ class: 'statistics-table-number' },
+												db.User.getById(processorId) || _('Unknown user')),
+										oToArray(processorResult, function (data, key) {
+											return td({ class: 'statistics-table-number' }, data);
+										})
+									);
+								});
+							}) : tr(td({ class: 'empty statistics-table-info', colspan: 6 },
 						_("No data for this criteria"))))));
 		}));
 };

--- a/view/statistics-flow-operators.js
+++ b/view/statistics-flow-operators.js
@@ -132,11 +132,7 @@ exports['statistics-main'] = function () {
 						th({ class: 'statistics-table-number' }, _("Sent Back for corrections")),
 						th({ class: 'statistics-table-number' }, _("Rejected"))
 					),
-					tbody(Object.keys(result).map(function (date) {
-						if (!Object.keys(result[date]).length) {
-							return tr(td({ class: 'empty statistics-table-info', colspan: 6 },
-								_("No data for this criteria")));
-						}
+					tbody(Object.keys(result).length ? Object.keys(result).map(function (date) {
 						return Object.keys(result[date]).map(function (processorId) {
 							return tr(list(Object.keys(result[date][processorId]), function (prop) {
 								var display;
@@ -149,6 +145,7 @@ exports['statistics-main'] = function () {
 								return td({ class: 'statistics-table-number' }, display);
 							}));
 						});
-					}))));
+					}) : tr(td({ class: 'empty statistics-table-info', colspan: 6 },
+						_("No data for this criteria"))))));
 		}));
 };

--- a/view/utils/statistics-flow-operators-query-server.js
+++ b/view/utils/statistics-flow-operators-query-server.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var memoize = require('memoizee')
+  , getData = require('mano/lib/client/xhr-driver').get;
+
+module.exports = memoize(function (query) {
+	return getData('/get-flow-roles-operators-data/', query);
+}, {
+	normalizer: function (args) { return JSON.stringify(args[0]); },
+	max: 1000
+});


### PR DESCRIPTION
Specification: https://docs.google.com/document/d/1i92UhTr_krhLYVc9TA88WGIrvwPAnM9x84WHCFpVtQc/edit

Additional important details to be found at #1759

UX mockup: http://xwv4ez.axshare.com/#p=table_of_quantities_of_files_processed_in_roles__p

It should come with server GET controller that will retrieve needed data using utilities configured at #1758 

The filter bar should expose on url query with: `service`, `step`, `operator`, `dateFrom`, `dateTo` and `mode` (either _daily_, _weekly_, _monthly_ or _yearly_).
Additionally each roles will have individual pagination which will enrich url query with queries as `revisionPage`, `precalPage` etc.

Server should be queried with two kind of queries:
A. Data for all tables (strictly first page)
B. Data for specific table (any page apart of first).

When we enter the page, or change settings in main filter page for tables is alwasy reset to `1` (therefore all eventual `revisionPage`, `precalPage` etc. should dissapear from query).

In that case we will query server with query of kind _A_, in which we pass:  `dateFrom`, `dateTo`,  and `mode`.

In case when user operates with paginator of one of chosen tables, then we quer server with query of kind _B_, in which we pass: `step`, `dateFrom`, `dateTo`, `mode` and `page`

Otherwise _service_,  _status_ and _operator_ filters should be resolved locally (server will respond with data for all combinations).

Result of server queries should be cached on client, we should not query server with same question twice (there's no chance result will change).

The data format as returned by server controller to client was already agreed at #1758, it'll be as:

for daily `mode`:

```javascript
{
  "2016-01-02": periodSums,
  "2016-01-03": periodSums,
  "2016-01-04": periodSums
  etc.
}
```
or for monthly `mode`:
```javascript
{
  "2016-01": periodSums, 
  "2016-02": periodSums,
  "2016-03": periodSums
  etc.
}
```

Where `periodSums` should most likely be reduced results of `calcuateStatusEventsSums` (as implemented at #1758)

The _direct_ result of `calcuateStatusEventsSums` would be as:

```
data.businessProcess[name][status] = sum
data.certificate[name][status] = sum
data.processingStep[name][processorId][status] = sum
```

While for this view we need to have it reduced to:
In query of kind A:
```
data.processingStep[name][processorId][status] = sum
```
In query of kind B:
```
data.processingStep.stepName[processorId][status] = sum
```

The normalization best if done on server (so client receives it already normalized) as we will also need same data format for PDF and CSV views as generated on server.

