### PR TITLE
Stats: Tables: Certificates:  CSV generation

### DIFF
--- a/server/csv-renderers/statistics-flow-certificates.js
+++ b/server/csv-renderers/statistics-flow-certificates.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var ensureObject = require('es5-ext/object/valid-object')
+  , _            = require('mano').i18n.bind('Statistics certificates csv')
+  , modes        = require('../../utils/statistics-flow-group-modes');
+
+module.exports = function (result, config) {
+	ensureObject(config);
+	var data, mode;
+	mode = modes.get(config.mode || 'daily');
+	data = [
+		[
+			mode.labelNoun,
+			_("Submitted"),
+			_("Pending"),
+			_("Ready for withdraw"),
+			_("Withdrawn by user"),
+			_("Rejected"),
+			_("Sent back for correction")
+		].join(',')
+	];
+
+	Object.keys(result).forEach(function (date) {
+		var resultItem = [mode.getDisplayedKey(new Date(date))];
+		Array.prototype.push.apply(resultItem,
+			Object.keys(result[date]).map(function (status) {
+				return result[date][status];
+			}));
+		data.push(resultItem.join(','));
+	});
+
+	return data.join('\n');
+};

--- a/server/routes/statistics.js
+++ b/server/routes/statistics.js
@@ -18,6 +18,7 @@ var assign                  = require('es5-ext/object/assign')
   , timePerPersonPrint      = require('../pdf-renderers/statistics-time-per-person')
   , timePerRolePrint        = require('../pdf-renderers/statistics-time-per-role')
   , timePerRoleCsv          = require('../csv-renderers/statistics-time-per-role')
+  , flowCertificatesCsv     = require('../csv-renderers/statistics-flow-certificates')
   , makePdf                 = require('./utils/pdf')
   , makeCsv                 = require('./utils/csv')
   , getBaseRoutes           = require('./authenticated')
@@ -127,6 +128,20 @@ module.exports = function (config) {
 				});
 
 				return flowCertificatesPrint(flowCertificatesFilter(result, query),
+					assign({ mode: query.mode }, rendererConfig));
+			});
+		}),
+		'flow-certificates-data.csv': makeCsv(function (query) {
+			return flowQueryCertificatesPdfHandler.resolve(query)(function (query) {
+				var dateRanges, result = {}, mode;
+				mode = modes.get(query.mode);
+				dateRanges = getDateRangesByMode(query.dateFrom, query.dateTo, query.mode);
+				dateRanges.forEach(function (dateRange) {
+					// dateRange: { dateFrom: db.Date, dateTo: db.Date } with dateRange query for result
+					result[mode.getDisplayedKey(dateRange.dateFrom)] = {};
+				});
+
+				return flowCertificatesCsv(flowCertificatesFilter(result, query),
 					assign({ mode: query.mode }, rendererConfig));
 			});
 		}),

--- a/view/statistics-flow-certificates.js
+++ b/view/statistics-flow-certificates.js
@@ -137,6 +137,13 @@ exports['statistics-main'] = function () {
 					getDynamicUrl('/flow-certificates-data.pdf', { only: params }),
 					target: '_blank' }, span({ class: 'fa fa-print' }), " ", _("Print pdf"))
 			),
+
+			div(
+				a({ class: 'users-table-filter-bar-print',
+					href: getDynamicUrl('/flow-certificates-data.csv', { only: params }),
+					target: '_blank' }, span({ class: 'fa fa-print' }), " ", _("Print csv"))
+			),
+
 			p({ class: 'submit' }, input({ type: 'submit' }))));
 
 	section(pagination);


### PR DESCRIPTION
Server-side generated CSV representation of view implemented at #1764

It should generate sheet of data representing same filtered version of view as one from which CSV request was initiated (query parameters needs to be passed to CSV url).

Still the page at which view is at is irrelevant, in all cases we should generate rows for whole selected period.
