### PR TITLE
In legacy controls-map control, allow persisting name attribute on parent elements.

### DIFF
--- a/client/legacy/controls-map.js
+++ b/client/legacy/controls-map.js
@@ -48,7 +48,7 @@ module.exports = function (config) {
 			setTimeout(function () { self(childSelect); }, 300);
 			return;
 		}
-		if (config.persistParentName) {
+		if (!config.persistParentName) {
 			parentSelect.removeAttribute('name');
 		}
 

--- a/client/legacy/controls-map.js
+++ b/client/legacy/controls-map.js
@@ -48,7 +48,9 @@ module.exports = function (config) {
 			setTimeout(function () { self(childSelect); }, 300);
 			return;
 		}
-		parentSelect.removeAttribute('name');
+		if (config.persistParentName) {
+			parentSelect.removeAttribute('name');
+		}
 
 		child = childSelect.value;
 

--- a/scripts/generate-legacy-controls-map.js
+++ b/scripts/generate-legacy-controls-map.js
@@ -26,7 +26,10 @@ module.exports = function (projectRoot, config) {
 
 	ensureString(projectRoot);
 	debug('generate-legacy-' + ensureString(config.fileNamePrefix) + '-data');
-	result.htmlClass       = ensureString(config.htmlClass);
+	result.htmlClass = ensureString(config.htmlClass);
+	if (config.persistParentName != null) {
+		result.persistParentName = config.persistParentName;
+	}
 	ensureString(config.linkingPropertyName);
 
 	ensureType(config.child).instances.forEach(function (child) {


### PR DESCRIPTION
This is needed for cases of one control-map parent is a child in other control-map. Needed by https://github.com/egovernment/eregistrations-salvador/pull/1728