### PR TITLE
Modify component totals-in-matrix.js to skip empty paths and vertical total

### DIFF
--- a/view/components/utils/totals-in-matrix.js
+++ b/view/components/utils/totals-in-matrix.js
@@ -8,7 +8,7 @@ var generateTableBody = function (rows, master) {
 	return rows.map(function (row) {
 		return tr(th(row.label, span({ class: 'hint' }, row.inputHint)),
 			list(row.paths, function (path) {
-				if (!path) return td();
+				if (path == null) return td();
 				var resolved = master.resolveSKeyPath(path);
 				return td(input({
 					control: { id: 'matrix-display-input-' + path },
@@ -72,12 +72,12 @@ module.exports = function (config) {
 			td({ id: totalId })
 		)),
 
-		script(function (formId, horizontalTotals, verticalTotals, skipVerticalTotal, totalId) {
+		script(function (formId, horizontalTotals, verticalTotals, totalId) {
 			var form = $(formId), totals = [], fullTotal = { total: $(totalId), subTotals: [] };
 			$.forEach(horizontalTotals.concat(verticalTotals), function (total) {
 				var subTotatals = [];
 				$.forEach(total.paths, function (path) {
-					if (!path) return;
+					if (path == null) return;
 					subTotatals.push($('matrix-display-input-' + path));
 				});
 				totals.push({
@@ -88,12 +88,12 @@ module.exports = function (config) {
 			$.forEach(verticalTotals, function (total) {
 				var subTotatals = [];
 				$.forEach(total.paths, function (path) {
-					if (!path) return;
+					if (path == null) return;
 					subTotatals.push($('matrix-display-input-' + path));
 				});
 				fullTotal.subTotals = fullTotal.subTotals.concat(subTotatals);
 			});
-			if (!skipVerticalTotal) totals.push(fullTotal);
+			if (verticalTotals.length > 0) totals.push(fullTotal);
 
 			$.onEnvUpdate(form, function () {
 				$.forEach(totals, function (total) {
@@ -104,5 +104,5 @@ module.exports = function (config) {
 					total.total.innerText = sum.toLocaleString();
 				});
 			});
-		}, formId, horizontalTotals, verticalTotals, skipVerticalTotal, totalId));
+		}, formId, horizontalTotals, verticalTotals, totalId));
 };

--- a/view/components/utils/totals-in-matrix.js
+++ b/view/components/utils/totals-in-matrix.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
 			verticalTotals.push(verticalTotal);
 			row.totalId = verticalTotal.totalId;
 		});
-	};
+	}
 	//horizontal totals
 	rows[0].paths.forEach(function (path, index) {
 		horizontalTotal = {

--- a/view/components/utils/totals-in-matrix.js
+++ b/view/components/utils/totals-in-matrix.js
@@ -8,6 +8,7 @@ var generateTableBody = function (rows, master) {
 	return rows.map(function (row) {
 		return tr(th(row.label, span({ class: 'hint' }, row.inputHint)),
 			list(row.paths, function (path) {
+				if (!path) return td();
 				var resolved = master.resolveSKeyPath(path);
 				return td(input({
 					control: { id: 'matrix-display-input-' + path },
@@ -20,26 +21,29 @@ var generateTableBody = function (rows, master) {
 };
 
 module.exports = function (config) {
-	var horizontalTotal, horizontalTotals = [], verticalTotals = [], totalId,
-		rows, columnLabels, lastRowLabel, tableId, master, formId;
+	var horizontalTotal, horizontalTotals = [], verticalTotals = [], skipVerticalTotal,
+		totalId, rows, columnLabels, lastRowLabel, tableId, master, formId;
 	ensureObject(config);
-	rows         = ensureArray(config.rows);
-	columnLabels = ensureArray(config.columnLabels);
-	lastRowLabel = config.lastRowLabel;
-	master       = ensureObject(config.master);
-	tableId      = config.tableId || generateId();
-	formId       = config.formId || tableId;
+	rows              = ensureArray(config.rows);
+	columnLabels      = ensureArray(config.columnLabels);
+	lastRowLabel      = config.lastRowLabel;
+	master            = ensureObject(config.master);
+	tableId           = config.tableId || generateId();
+	formId            = config.formId || tableId;
+	skipVerticalTotal = config.skipVerticalTotal;
 
 	totalId = generateId('total');
 	//vertical totals
-	rows.forEach(function (row) {
-		var verticalTotal = {
-			totalId: generateId('total'),
-			paths: row.paths
-		};
-		verticalTotals.push(verticalTotal);
-		row.totalId = verticalTotal.totalId;
-	});
+	if (!skipVerticalTotal) {
+		rows.forEach(function (row) {
+			var verticalTotal = {
+				totalId: generateId('total'),
+				paths: row.paths
+			};
+			verticalTotals.push(verticalTotal);
+			row.totalId = verticalTotal.totalId;
+		});
+	};
 	//horizontal totals
 	rows[0].paths.forEach(function (path, index) {
 		horizontalTotal = {
@@ -68,11 +72,12 @@ module.exports = function (config) {
 			td({ id: totalId })
 		)),
 
-		script(function (formId, horizontalTotals, verticalTotals, totalId) {
+		script(function (formId, horizontalTotals, verticalTotals, skipVerticalTotal, totalId) {
 			var form = $(formId), totals = [], fullTotal = { total: $(totalId), subTotals: [] };
 			$.forEach(horizontalTotals.concat(verticalTotals), function (total) {
 				var subTotatals = [];
 				$.forEach(total.paths, function (path) {
+					if (!path) return;
 					subTotatals.push($('matrix-display-input-' + path));
 				});
 				totals.push({
@@ -83,11 +88,12 @@ module.exports = function (config) {
 			$.forEach(verticalTotals, function (total) {
 				var subTotatals = [];
 				$.forEach(total.paths, function (path) {
+					if (!path) return;
 					subTotatals.push($('matrix-display-input-' + path));
 				});
 				fullTotal.subTotals = fullTotal.subTotals.concat(subTotatals);
 			});
-			totals.push(fullTotal);
+			if (!skipVerticalTotal) totals.push(fullTotal);
 
 			$.onEnvUpdate(form, function () {
 				$.forEach(totals, function (total) {
@@ -98,5 +104,5 @@ module.exports = function (config) {
 					total.total.innerText = sum.toLocaleString();
 				});
 			});
-		}, formId, horizontalTotals, verticalTotals, totalId));
+		}, formId, horizontalTotals, verticalTotals, skipVerticalTotal, totalId));
 };


### PR DESCRIPTION
Existing component totals-in-matrix.js has to be changed in order to meet new requirements. Two changes have to be implemented.

Firstly, this component has to be able to configure so that it would not calculate vertical totals.

Secondly, all the properties do not have both asset and liability value, therefore it is necessary to change the component in the manner that in case the property path is empty, it will display empty nothing in the field position. 