### PR TITLE
The rejection reasons disappears when I go to an other page

### DIFF
--- a/view/components/filter-bar/select-date-range.js
+++ b/view/components/filter-bar/select-date-range.js
@@ -14,6 +14,7 @@
 var _ = require('mano').i18n.bind('Daterange')
   , dateFrom = require('./select-date-from')
   , dateTo = require('./select-date-to')
+  , location = require('mano/lib/client/location')
   , moment = window.moment
   , jQuery = window.jQuery;
 
@@ -117,6 +118,20 @@ module.exports = function (/* opts */) {
 			jQuery('#endId').val(dateToString(range.end));
 			$.dispatchEvent($('startId'), 'change');
 			$.dispatchEvent($('endId'), 'change');
+		});
+
+		var path;
+		path = location.pathname;
+		location.on('change', function () {
+			if (location.pathname !== path) {
+				path = location.pathname;
+				if (elem) {
+					elem.daterangepicker("setRange", {
+						start: stringToDate(jQuery('#startId').val()),
+						end: stringToDate(jQuery('#endId').val())
+					});
+				}
+			}
 		});
 	});
 

--- a/view/components/filter-bar/select-date-range.js
+++ b/view/components/filter-bar/select-date-range.js
@@ -120,8 +120,7 @@ module.exports = function (/* opts */) {
 			$.dispatchEvent($('endId'), 'change');
 		});
 
-		var path;
-		path = location.pathname;
+		var path = location.pathname;
 		location.on('change', function () {
 			if (location.pathname !== path) {
 				path = location.pathname;


### PR DESCRIPTION
reported here: https://unctad.atlassian.net/browse/EV2CORE-7

The content of the rejection reasons disappears when I go to an other page and come back. To reproduce this bug, do the following: 1. go to Rejections reason page, 2. select "Since the start of the system" (dates are set from Sept 1st, 2016), 3. see the data (the table is filled), 4. go to an other page, 5. come back to Reasons of rejections → the period is the same, the table is empty.