### PR TITLE
Show name of the document that was rejected in reasons for rejection statistics view

### DIFF
--- a/test/utils/statistics-flow-rejection-reason-results.js
+++ b/test/utils/statistics-flow-rejection-reason-results.js
@@ -54,9 +54,9 @@ module.exports = function (t, a) {
 	expected = [[
 		[
 			'not good',
-			'Document 1 - The document is unreadable',
-			'Document 1 - The loaded document does not match the required document',
-			'Document 2 - junk'
+			'Passport - The document is unreadable',
+			'Passport - The loaded document does not match the required document',
+			'Invoice for electrical energy services - junk'
 		],
 		'',
 		'',

--- a/test/utils/statistics-flow-rejection-reason-results.js
+++ b/test/utils/statistics-flow-rejection-reason-results.js
@@ -54,9 +54,9 @@ module.exports = function (t, a) {
 	expected = [[
 		[
 			'not good',
-			'Passport - The document is unreadable',
-			'Passport - The loaded document does not match the required document',
-			'Invoice for electrical energy services - junk'
+			'Document - The document is unreadable',
+			'Document - The loaded document does not match the required document',
+			'Document - junk'
 		],
 		'',
 		'',

--- a/utils/statistics-flow-rejection-reason-results.js
+++ b/utils/statistics-flow-rejection-reason-results.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var db = require('../db');
+var _  = require('mano').i18n.bind('Routes: Statistics')
+  , db = require('../db');
 
 module.exports = function (reasons) {
 	return reasons.map(function (reason) {
@@ -8,7 +9,7 @@ module.exports = function (reasons) {
 		  , prefix, uploadParent, upload;
 		reason.rejectionReasons.forEach(function (reasonItem) {
 			if (reasonItem.ownerType === 'processingStep') prefix = '';
-			else if (reasonItem.ownerType === 'data') prefix = 'Data - ';
+			else if (reasonItem.ownerType === 'data') prefix = _('Data') + ' - ';
 			else {
 					try {
 						uploadParent = reasonItem.path.slice(1, reasonItem.path.slice(1).indexOf('/') + 1);
@@ -17,7 +18,7 @@ module.exports = function (reasons) {
 						prefix += ' - ';
 					} catch (e) {
 						//document's label that was rejected cannot be detected
-						prefix = 'Document - ';
+						prefix = _('Document') + ' - ';
 					}
 				}
 			reasonItem.types.forEach(function (type) {

--- a/utils/statistics-flow-rejection-reason-results.js
+++ b/utils/statistics-flow-rejection-reason-results.js
@@ -15,11 +15,11 @@ module.exports = function (reasons) {
 						uploadParent = reasonItem.path.slice(1, reasonItem.path.slice(1).indexOf('/') + 1);
 						upload = reasonItem.path.slice(reasonItem.path.lastIndexOf('/') + 1);
 						prefix = db[reason.service.type].prototype[uploadParent].map[upload].document.label;
-						prefix += ' - ';
 					} catch (e) {
 						//document's label that was rejected cannot be detected
-						prefix = _('Document') + ' - ';
+						prefix = _('Document');
 					}
+					prefix += ' - ';
 				}
 			reasonItem.types.forEach(function (type) {
 				if (type === 'other') {

--- a/utils/statistics-flow-rejection-reason-results.js
+++ b/utils/statistics-flow-rejection-reason-results.js
@@ -5,13 +5,20 @@ var db = require('../db');
 module.exports = function (reasons) {
 	return reasons.map(function (reason) {
 		var result = [], reasonsConcat = []
-		  , prefix, prefixCount = 0;
+		  , prefix, uploadParent, upload;
 		reason.rejectionReasons.forEach(function (reasonItem) {
 			if (reasonItem.ownerType === 'processingStep') prefix = '';
 			else if (reasonItem.ownerType === 'data') prefix = 'Data - ';
 			else {
-					prefixCount++;
-					prefix = 'Document ' + prefixCount + ' - ';
+					try {
+						uploadParent = reasonItem.path.slice(1, reasonItem.path.slice(1).indexOf('/') + 1);
+						upload = reasonItem.path.slice(reasonItem.path.lastIndexOf('/') + 1);
+						prefix = db[reason.service.type].prototype[uploadParent].map[upload].document.label;
+						prefix += ' - ';
+					} catch (e) {
+						//document's label that was rejected cannot be detected
+						prefix = 'Document - ';
+					}
 				}
 			reasonItem.types.forEach(function (type) {
 				if (type === 'other') {


### PR DESCRIPTION
Currently in the reasons for rejection statistics view requirementUploads and paymentReceiptUploads are both grouped to "Documents (n) - ". 


![image](https://cloud.githubusercontent.com/assets/11193108/25662602/cb9dc928-301d-11e7-985e-b8b647d790b1.png)

This is not [what was wanted](https://unctad.atlassian.net/browse/EV2CORE-3?focusedCommentId=16075&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16075).
Instead it should display the name of the paymentReceiptUpload or rejectionUpload document that was rejected or sent for corrections. Like so:

![image](https://cloud.githubusercontent.com/assets/11193108/25662677/044ac30c-301e-11e7-8ab3-3e77ff74461c.png)
