### PR TITLE
rejection reasons statistics csv export formation issues

### DIFF
--- a/server/csv-renderers/statistics-flow-rejections.js
+++ b/server/csv-renderers/statistics-flow-rejections.js
@@ -14,8 +14,10 @@ module.exports = function (result, config) {
 	];
 
 	data.push.apply(data, result.map(function (row) {
-		row[0] = '\"' + row[0].join(' ').replace(/\r?\n|\r/g, ' ').replace(/"/g, "'") + '\"';
-		row[row.length - 1] = '\"' + row[row.length - 1].replace(/"/g, "'") + '\"';
+		row.forEach(function (column, index) {
+			if (column.constructor === Array) column = column.join(' ');
+			row[index] = '\"' + column.replace(/\r?\n|\r/g, ' ').replace(/"/g, "'") + '\"';
+		});
 		return row;
 	}));
 

--- a/server/csv-renderers/statistics-flow-rejections.js
+++ b/server/csv-renderers/statistics-flow-rejections.js
@@ -15,6 +15,7 @@ module.exports = function (result, config) {
 
 	data.push.apply(data, result.map(function (row) {
 		row.forEach(function (column, index) {
+			if (column.constructor === Number) return;
 			if (column.constructor === Array) column = column.join(' ');
 			row[index] = '\"' + column.replace(/\r?\n|\r/g, ' ').replace(/"/g, "'") + '\"';
 		});

--- a/server/csv-renderers/statistics-flow-rejections.js
+++ b/server/csv-renderers/statistics-flow-rejections.js
@@ -14,7 +14,8 @@ module.exports = function (result, config) {
 	];
 
 	data.push.apply(data, result.map(function (row) {
-		row[0] = row[0].join(' ').replace(/\r?\n|\r/g, ' ').replace(/,/g, ' ');
+		row[0] = '\"' + row[0].join(' ').replace(/\r?\n|\r/g, ' ').replace(/"/g, "'") + '\"';
+		row[row.length - 1] = '\"' + row[row.length - 1].replace(/"/g, "'") + '\"';
 		return row;
 	}));
 


### PR DESCRIPTION
When the explanation of rejection reason contains single or double quotes in it or when last column (business name) contains single or double quotes or comma, it will break the CSV formation.

These fields have to be surrounded by double quotes and all existing double quotes in them have to be replaced with single quotes. Then it also no longer matters whether these columns contain commas. Source: http://stackoverflow.com/a/8497474