### PR TITLE
Enable options support in get-soap-client utils.

### DIFF
--- a/utils/get-soap-client.js
+++ b/utils/get-soap-client.js
@@ -11,10 +11,10 @@ var memoize          = require('memoizee')
 
   , createSoapClient = promisify(soap.createClient);
 
-var getSoapClientImpl = memoize(function (wsdlUrl, soapUrl) {
-	debug('creating soap client (%s)', soapUrl);
+var getSoapClientImpl = memoize(function (wsdlUrl, options) {
+	debug('creating soap client (%s)', options.endpoint);
 
-	return createSoapClient(wsdlUrl, { endpoint: soapUrl })(function (client) {
+	return createSoapClient(wsdlUrl, options)(function (client) {
 		var services = client.wsdl.definitions.services
 		  , ports, methods, method, promisifiedMethodName;
 
@@ -39,8 +39,10 @@ var getSoapClientImpl = memoize(function (wsdlUrl, soapUrl) {
 	});
 }, { primitive: true });
 
-module.exports = function (wsdlUrl, soapUrl) {
-	return getSoapClientImpl(wsdlUrl, soapUrl).aside(null, function (err) {
-		getSoapClientImpl.clear(wsdlUrl, soapUrl);
+module.exports = function (wsdlUrl, soapUrl/*, options*/) {
+	var options = Object(arguments[2]);
+	options.endpoint = soapUrl;
+	return getSoapClientImpl(wsdlUrl, options).aside(null, function (err) {
+		getSoapClientImpl.clear(wsdlUrl, options);
 	});
 };

--- a/utils/get-soap-client.js
+++ b/utils/get-soap-client.js
@@ -11,7 +11,8 @@ var memoize          = require('memoizee')
 
   , createSoapClient = promisify(soap.createClient);
 
-var getSoapClientImpl = memoize(function (wsdlUrl, options) {
+var getSoapClientImpl = memoize(function (wsdlUrl/*, options*/) {
+	var options = Object(arguments[1]);
 	debug('creating soap client (%s)', options.endpoint);
 
 	return createSoapClient(wsdlUrl, options)(function (client) {


### PR DESCRIPTION
the util that handles creating soap client has to be modified in a way that it would support passing options argument to soap module's createClient() function.
By doing so it will allow us to adjust the default soap client generation as we deem necessary.

First use case occurred in https://github.com/egovernment/eregistrations-salvador/issues/1808 where it's necessary to force namespace prefix usage in methodName in order to receive proper results from the service.

JIRA issue: https://unctad.atlassian.net/browse/ELS-25