### PR TITLE
Skip part-A step if applicable document size equals 0

### DIFF
--- a/view/business-process-data-forms-section-tab.js
+++ b/view/business-process-data-forms-section-tab.js
@@ -34,6 +34,10 @@ exports._disableCondition = function () {
 	return not(eq(this.businessProcess._guideProgress, 1));
 };
 
-exports._nextSectionUrl = function () { return '/documents/'; };
+exports._nextSectionUrl = function () {
+	return _if(eq(this.businessProcess.requirementUploads.applicable._size, 0),
+		_if(eq(this.businessProcess.costs._paymentWeight, 0), '/submission/', '/pay/'),
+		'/documents/');
+};
 
 exports._match = 'section';

--- a/view/business-process-data-forms.js
+++ b/view/business-process-data-forms.js
@@ -14,7 +14,9 @@ exports._parent = require('./business-process-base');
 exports.step = function () {
 	var businessProcess = this.businessProcess
 	  , dataForms       = businessProcess.dataForms
-	  , guideProgress   = businessProcess._guideProgress;
+	  , guideProgress   = businessProcess._guideProgress
+	  , applicableDocs  = businessProcess.requirementUploads.applicable._size;
+
 
 	exports._formsHeading.call(this);
 
@@ -31,7 +33,13 @@ exports.step = function () {
 	insert(_if(and(eq(guideProgress, 1),
 		eq(dataForms._progress, 1)),
 		div({ class: 'user-next-step-button' },
-			a({ href: '/documents/' }, _("Continue to next step"))),
+			_if(eq(applicableDocs, 0),
+				_if(eq(businessProcess.costs._paymentWeight, 0),
+					a({ href: '/submission/' }, _("Continue to next step")),
+					a({ href: '/pay/' }, _("Continue to next step"))
+					),
+				a({ href: '/documents/' }, _("Continue to next step"))
+				)),
 		_if(gt(dataForms._progress, 0), section({ class: 'section-warning' },
 			incompleteFormNav(dataForms.applicable)))
 		));

--- a/view/business-process-data-forms.js
+++ b/view/business-process-data-forms.js
@@ -17,7 +17,6 @@ exports.step = function () {
 	  , guideProgress   = businessProcess._guideProgress
 	  , applicableDocs  = businessProcess.requirementUploads.applicable._size;
 
-
 	exports._formsHeading.call(this);
 
 	insert(errorMsg(this));

--- a/view/business-process-data-forms.js
+++ b/view/business-process-data-forms.js
@@ -29,16 +29,11 @@ exports.step = function () {
 		exports._forms.call(this)
 	);
 
-	insert(_if(and(eq(guideProgress, 1),
-		eq(dataForms._progress, 1)),
+	insert(_if(and(eq(guideProgress, 1), eq(dataForms._progress, 1)),
 		div({ class: 'user-next-step-button' },
-			_if(eq(applicableDocs, 0),
-				_if(eq(businessProcess.costs._paymentWeight, 0),
-					a({ href: '/submission/' }, _("Continue to next step")),
-					a({ href: '/pay/' }, _("Continue to next step"))
-					),
-				a({ href: '/documents/' }, _("Continue to next step"))
-				)),
+			a({ href: _if(eq(applicableDocs, 0), _if(eq(businessProcess.costs._paymentWeight, 0),
+				'/submission/', '/pay/'), '/documents/') }, _("Continue to next step"))
+			),
 		_if(gt(dataForms._progress, 0), section({ class: 'section-warning' },
 			incompleteFormNav(dataForms.applicable)))
 		));


### PR DESCRIPTION
In some of the end-systems it is possible that the size of applicable requirementUploads list is 0 in scope of one business process. In this situation user should not be directed to document upload step after he/she has finished filling forms.

It is also necessary to account with situation that this business process does not contain any costs. In this case payment step has to be skipped as well. 

The necessity of this modification came from: https://unctad.atlassian.net/browse/ELS-53