### PR TITLE
Enable creation in ws parser

### DIFF
--- a/webservice/parser.js
+++ b/webservice/parser.js
@@ -106,6 +106,9 @@ var assignValues = function (pathsMap, ourData, theirData/*, opts */) {
 			} else {
 				currentResult = currentResult[segment];
 			}
+			if (opts.ignoreCurrentWS) {
+				ourCurrentData[segment] = {};
+			}
 			ourCurrentData = ourCurrentData[segment];
 		});
 		theirCurrentData = theirData;
@@ -139,9 +142,9 @@ var assignValues = function (pathsMap, ourData, theirData/*, opts */) {
 module.exports = function (bp, inputMap, theirData/*, opts */) {
 	var filteredMap = {}, wsJSON, opts;
 	opts = Object(arguments[3]);
-	wsJSON = bp.toWebServiceJSON(opts);
+	wsJSON = opts.ignoreCurrentWS ? {} : bp.toWebServiceJSON(opts);
 	Object.keys(inputMap).forEach(function (mapKey) {
-		if (!isPathValid(wsJSON, mapKey)) return;
+		if (!opts.ignoreCurrentWS && !isPathValid(wsJSON, mapKey)) return;
 		if (!isPathValid(theirData, inputMap[mapKey])) return;
 		if (mapKey.indexOf('*') !== -1) {
 			Object.assign(filteredMap,


### PR DESCRIPTION
Currently parser assumes that it operates on full toWSJSON data set. If it cannot find matching entries in the json it ignores give path. This strategy is not good for unfinished bps. I'm adding an option to bypass this behavior, so I can use the parser in scope of: https://github.com/egovernment/eregistrations-salvador/pull/1969 (when at the moment of ws calling, there is hardly any data returned from toWSJSON).